### PR TITLE
pip page for qiskit-superstaq has a broken link

### DIFF
--- a/qiskit-superstaq/setup.py
+++ b/qiskit-superstaq/setup.py
@@ -36,7 +36,7 @@ qiskit_superstaq_packages = ["qiskit_superstaq"] + [
 setup(
     name=name,
     version=__version__,
-    url="https://github.com/SupertechLabs/qiskit-superstaq",
+    url="https://github.com/Infleqtion/client-superstaq",
     author="Super.tech",
     author_email="pranav@super.tech",
     python_requires=(">=3.7.0"),


### PR DESCRIPTION
pip page for qiskit-superstaq points to the previous location of this source code, I think.