### PR TITLE
remove deprecated calls from daily integration checks

### DIFF
--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -80,14 +80,12 @@ def test_aqt_compile_eca(service: css.Service) -> None:
         cirq.CX(cirq.LineQubit(4), cirq.LineQubit(5)) ** 0.7,
     )
 
-    eca_circuits = service.aqt_compile_eca(
-        circuit, num_equivalent_circuits=3, random_seed=123
-    ).circuits
+    eca_circuits = service.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
     assert len(eca_circuits) == 3
     assert all(isinstance(circuit, cirq.Circuit) for circuit in eca_circuits)
 
     # multiple circuits:
-    eca_circuits = service.aqt_compile_eca([circuit, circuit], num_equivalent_circuits=3).circuits
+    eca_circuits = service.aqt_compile([circuit, circuit], num_eca_circuits=3).circuits
     assert len(eca_circuits) == 2
     for circuits in eca_circuits:
         assert len(circuits) == 3
@@ -100,17 +98,15 @@ def test_aqt_compile_eca_regression(service: css.Service) -> None:
         cirq.H(cirq.LineQubit(4)),
         cirq.CX(cirq.LineQubit(4), cirq.LineQubit(5)) ** 0.7,
     )
-    eca_circuits = service.aqt_compile_eca(
-        circuit, num_equivalent_circuits=3, random_seed=123
+    eca_circuits = service.aqt_compile(
+        circuit, num_eca_circuits=3, random_seed=123
     ).circuits
     # test with same and different seed
     assert (
-        eca_circuits
-        == service.aqt_compile_eca(circuit, num_equivalent_circuits=3, random_seed=123).circuits
+        eca_circuits == service.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
     )
     assert (
-        eca_circuits
-        != service.aqt_compile_eca(circuit, num_equivalent_circuits=3, random_seed=456).circuits
+        eca_circuits != service.aqt_compile(circuit, num_eca_circuits=3, random_seed=456).circuits
     )
 
 

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -98,9 +98,7 @@ def test_aqt_compile_eca_regression(service: css.Service) -> None:
         cirq.H(cirq.LineQubit(4)),
         cirq.CX(cirq.LineQubit(4), cirq.LineQubit(5)) ** 0.7,
     )
-    eca_circuits = service.aqt_compile(
-        circuit, num_eca_circuits=3, random_seed=123
-    ).circuits
+    eca_circuits = service.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
     # test with same and different seed
     assert (
         eca_circuits == service.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits

--- a/qiskit-superstaq/qiskit_superstaq/compiler_output.py
+++ b/qiskit-superstaq/qiskit_superstaq/compiler_output.py
@@ -154,9 +154,7 @@ class CompilerOutput:
 
 
 def read_json_aqt(
-    json_dict: Dict[str, str],
-    circuits_is_list: bool,
-    num_equivalent_circuits: Optional[int] = None,
+    json_dict: Dict[str, str], circuits_is_list: bool, num_eca_circuits: Optional[int] = None
 ) -> CompilerOutput:
     """Reads out the returned JSON from Superstaq API's AQT compilation endpoint.
 
@@ -164,8 +162,8 @@ def read_json_aqt(
         json_dict: A JSON dictionary matching the format returned by /aqt_compile endpoint.
         circuits_is_list: Bool flag that controls whether the returned object has a .circuits
             attribute (if True) or a .circuit attribute (False).
-        num_equivalent_circuits: Optional number of logically equivalent random circuits to generate
-            for each input circuit.
+        num_eca_circuits: Optional number of logically equivalent random circuits to generate for
+            each input circuit.
 
     Returns:
         A `CompilerOutput` object with the compiled circuit(s). If qtrl is available locally,
@@ -222,19 +220,19 @@ def read_json_aqt(
 
         seq = _sequencer_from_state(state)
 
-    if num_equivalent_circuits is not None:
+    if num_eca_circuits is not None:
         compiled_circuits = [
-            compiled_circuits[i : i + num_equivalent_circuits]
-            for i in range(0, len(compiled_circuits), num_equivalent_circuits)
+            compiled_circuits[i : i + num_eca_circuits]
+            for i in range(0, len(compiled_circuits), num_eca_circuits)
         ]
 
         pulse_lists = pulse_lists and [
-            pulse_lists[i : i + num_equivalent_circuits]
-            for i in range(0, len(pulse_lists), num_equivalent_circuits)
+            pulse_lists[i : i + num_eca_circuits]
+            for i in range(0, len(pulse_lists), num_eca_circuits)
         ]
         final_logical_to_physicals = [
-            final_logical_to_physicals_list[i : i + num_equivalent_circuits]
-            for i in range(0, len(final_logical_to_physicals_list), num_equivalent_circuits)
+            final_logical_to_physicals_list[i : i + num_eca_circuits]
+            for i in range(0, len(final_logical_to_physicals_list), num_eca_circuits)
         ]
 
     if circuits_is_list:

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -84,14 +84,12 @@ def test_aqt_compile_eca(provider: qss.SuperstaQProvider) -> None:
     circuit.h(4)
     circuit.crx(0.7 * np.pi, 4, 5)
 
-    eca_circuits = provider.aqt_compile_eca(
-        circuit, num_equivalent_circuits=3, random_seed=123
-    ).circuits
+    eca_circuits = provider.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
     assert len(eca_circuits) == 3
     assert all(isinstance(circuit, qiskit.QuantumCircuit) for circuit in eca_circuits)
 
     # multiple circuits:
-    eca_circuits = provider.aqt_compile_eca([circuit, circuit], num_equivalent_circuits=3).circuits
+    eca_circuits = provider.aqt_compile([circuit, circuit], num_eca_circuits=3).circuits
     assert len(eca_circuits) == 2
     for circuits in eca_circuits:
         assert len(circuits) == 3
@@ -104,18 +102,14 @@ def test_aqt_compile_eca_regression(provider: qss.SuperstaQProvider) -> None:
     circuit.h(4)
     circuit.crx(0.7 * np.pi, 4, 5)
 
-    eca_circuits = provider.aqt_compile_eca(
-        circuit, num_equivalent_circuits=3, random_seed=123
-    ).circuits
+    eca_circuits = provider.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
 
     # test with same and different seed
     assert (
-        eca_circuits
-        == provider.aqt_compile_eca(circuit, num_equivalent_circuits=3, random_seed=123).circuits
+        eca_circuits == provider.aqt_compile(circuit, num_eca_circuits=3, random_seed=123).circuits
     )
     assert (
-        eca_circuits
-        != provider.aqt_compile_eca(circuit, num_equivalent_circuits=3, random_seed=456).circuits
+        eca_circuits != provider.aqt_compile(circuit, num_eca_circuits=3, random_seed=456).circuits
     )
 
 


### PR DESCRIPTION
follow up to #566 - removes deprecated aqt_compile_eca calls from daily integration checks (instead uses `aqt_compile(..., num_eca_circuits=n)`)

also changes `num_equivalent_circuits` -> `num_eca_circuits` in `qss.compiler_output` for consistency with css