### PR TITLE
generalize input annotations from `List[<circuit_type>]` to `Sequence[<circuit_type>]`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -360,7 +360,7 @@ class Service(user_config.UserConfig):
         return self._client.get_targets()["superstaq_targets"]
 
     def resource_estimate(
-        self, circuits: Union[cirq.Circuit, List[cirq.Circuit]], target: Optional[str] = None
+        self, circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]], target: Optional[str] = None
     ) -> Union[ResourceEstimate, List[ResourceEstimate]]:
         """Generates resource estimates for circuit(s).
 
@@ -393,7 +393,7 @@ class Service(user_config.UserConfig):
 
     def aqt_compile_eca(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         num_equivalent_circuits: int,
         random_seed: Optional[int] = None,
         target: str = "aqt_keysight_qpu",
@@ -453,7 +453,7 @@ class Service(user_config.UserConfig):
 
     def aqt_compile(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         target: str = "aqt_keysight_qpu",
         *,
         num_eca_circuits: Optional[int] = None,
@@ -531,7 +531,7 @@ class Service(user_config.UserConfig):
 
     def qscout_compile(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         mirror_swaps: bool = False,
         base_entangling_gate: str = "xx",
         target: str = "sandia_qscout_qpu",
@@ -591,7 +591,7 @@ class Service(user_config.UserConfig):
 
     def cq_compile(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         target: str = "cq_hilbert_qpu",
         **kwargs: Any,
     ) -> css.compiler_output.CompilerOutput:
@@ -609,7 +609,7 @@ class Service(user_config.UserConfig):
 
     def ibmq_compile(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         target: str = "ibmq_qasm_simulator",
         **kwargs: Any,
     ) -> css.compiler_output.CompilerOutput:
@@ -639,7 +639,7 @@ class Service(user_config.UserConfig):
 
     def compile(
         self,
-        circuits: Union[cirq.Circuit, List[cirq.Circuit]],
+        circuits: Union[cirq.Circuit, Sequence[cirq.Circuit]],
         target: str,
         **kwargs: Any,
     ) -> css.compiler_output.CompilerOutput:

--- a/qiskit-superstaq/qiskit_superstaq/serialization.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization.py
@@ -2,7 +2,7 @@ import io
 import json
 import re
 import warnings
-from typing import Dict, List, Set, Tuple, TypeVar, Union
+from typing import Dict, List, Sequence, Set, Tuple, TypeVar, Union
 
 import general_superstaq as gss
 import numpy as np
@@ -117,7 +117,9 @@ def _assign_unique_inst_names(circuit: qiskit.QuantumCircuit) -> qiskit.QuantumC
     return new_circuit
 
 
-def serialize_circuits(circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]]) -> str:
+def serialize_circuits(
+    circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]]
+) -> str:
     """Serialize QuantumCircuit(s) into a single string
 
     Args:

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_backend.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import general_superstaq as gss
 import numpy as np
@@ -74,7 +74,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def run(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         shots: int,
         method: Optional[str] = None,
         options: Optional[Dict[str, Any]] = None,
@@ -122,7 +122,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles the given circuit(s) to the backend's native gateset.
@@ -159,7 +159,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def _get_compile_request_json(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         **kwargs: Any,
     ) -> Dict[str, str]:
         """"""
@@ -172,7 +172,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def aqt_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         *,
         num_eca_circuits: Optional[int] = None,
         random_seed: Optional[int] = None,
@@ -232,7 +232,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def ibmq_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles and optimizes the given circuit(s) for IBMQ devices.
@@ -275,7 +275,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def qscout_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         mirror_swaps: bool = True,
         base_entangling_gate: str = "xx",
         **kwargs: Any,
@@ -329,7 +329,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
 
     def cq_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
         """Compiles and optimizes the given circuit(s) for CQ devices.
@@ -363,7 +363,7 @@ class SuperstaQBackend(qiskit.providers.BackendV1):
         return self._provider._client.target_info(self.name())["target_info"]
 
     def resource_estimate(
-        self, circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]]
+        self, circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]]
     ) -> Union[gss.ResourceEstimate, List[gss.ResourceEstimate]]:
         """Generates resource estimates for qiskit circuit(s).
 

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -116,7 +116,7 @@ class SuperstaQProvider(qiskit.providers.ProviderV1, gss.user_config.UserConfig)
         return backends
 
     def resource_estimate(
-        self, circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]], target: str
+        self, circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]], target: str
     ) -> Union[gss.ResourceEstimate, List[gss.ResourceEstimate]]:
         """Generates resource estimates for qiskit circuit(s).
 
@@ -132,7 +132,7 @@ class SuperstaQProvider(qiskit.providers.ProviderV1, gss.user_config.UserConfig)
 
     def aqt_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         target: str = "aqt_keysight_qpu",
         *,
         num_eca_circuits: Optional[int] = None,
@@ -248,7 +248,7 @@ class SuperstaQProvider(qiskit.providers.ProviderV1, gss.user_config.UserConfig)
 
     def ibmq_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         target: str = "ibmq_qasm_simulator",
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:
@@ -272,7 +272,7 @@ class SuperstaQProvider(qiskit.providers.ProviderV1, gss.user_config.UserConfig)
 
     def qscout_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         mirror_swaps: bool = False,
         base_entangling_gate: str = "xx",
         target: str = "sandia_qscout_qpu",
@@ -316,7 +316,7 @@ class SuperstaQProvider(qiskit.providers.ProviderV1, gss.user_config.UserConfig)
 
     def cq_compile(
         self,
-        circuits: Union[qiskit.QuantumCircuit, List[qiskit.QuantumCircuit]],
+        circuits: Union[qiskit.QuantumCircuit, Sequence[qiskit.QuantumCircuit]],
         target: str = "cq_hilbert_qpu",
         **kwargs: Any,
     ) -> qss.compiler_output.CompilerOutput:


### PR DESCRIPTION
in general input annotations should be as general as possible (especially for public-facing functions). these methods don't actually require that circuits be passed as a proper `list` instance (tuples of circuits work just as well, for example)