### PR TITLE
remove broken + redundant API key tests in `css` and `qss`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/service_test.py
+++ b/cirq-superstaq/cirq_superstaq/service_test.py
@@ -592,12 +592,6 @@ def test_service_remote_host_via_env() -> None:
     assert service._client.remote_host == "http://example.com"
 
 
-@mock.patch.dict(os.environ, {"SUPERSTAQ_API_KEY": ""})
-def test_service_no_param_or_env_variable() -> None:
-    with pytest.raises(EnvironmentError):
-        _ = css.Service(remote_host="http://example.com")
-
-
 @mock.patch.dict(os.environ, clear=True)
 def test_service_no_url_default() -> None:
     service = css.Service("tomyheart")

--- a/general-superstaq/general_superstaq/check/check_utils.py
+++ b/general-superstaq/general_superstaq/check/check_utils.py
@@ -257,7 +257,12 @@ def get_file_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("-i", "--incremental", dest="revisions", nargs="*", help=help_text)
     parser.add_argument(
-        "-x", "--exclude", action="extend", nargs="+", metavar="GLOB", help="Exclude files matching GLOB."
+        "-x",
+        "--exclude",
+        action="extend",
+        nargs="+",
+        metavar="GLOB",
+        help="Exclude files matching GLOB.",
     )
 
     return parser

--- a/general-superstaq/general_superstaq/check/check_utils.py
+++ b/general-superstaq/general_superstaq/check/check_utils.py
@@ -257,7 +257,7 @@ def get_file_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("-i", "--incremental", dest="revisions", nargs="*", help=help_text)
     parser.add_argument(
-        "-x", "--exclude", action="append", metavar="GLOB", help="Exclude files matching GLOB."
+        "-x", "--exclude", action="extend", nargs="+", metavar="GLOB", help="Exclude files matching GLOB."
     )
 
     return parser

--- a/general-superstaq/general_superstaq/check/check_utils.py
+++ b/general-superstaq/general_superstaq/check/check_utils.py
@@ -257,7 +257,7 @@ def get_file_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("-i", "--incremental", dest="revisions", nargs="*", help=help_text)
     parser.add_argument(
-        "-x", "--exclude", action="extend", metavar="GLOB", help="Exclude files matching GLOB."
+        "-x", "--exclude", action="append", metavar="GLOB", help="Exclude files matching GLOB."
     )
 
     return parser

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider_test.py
@@ -18,9 +18,6 @@ import qiskit_superstaq as qss
 def test_provider() -> None:
     ss_provider = qss.SuperstaqProvider(api_key="MY_TOKEN")
 
-    with pytest.raises(EnvironmentError, match="Superstaq API key not specified and not found."):
-        qss.SuperstaqProvider()
-
     assert str(ss_provider.get_backend("ibmq_qasm_simulator")) == str(
         qss.SuperstaqBackend(provider=ss_provider, target="ibmq_qasm_simulator")
     )


### PR DESCRIPTION
These tests looks for a **failure** to find an API key, and therefore do not pass on my local machine: `qss` and `css` successfully find an API key in `~/.local/share/super.tech/superstaq_api_key`... as they should!

This bug breaks `./check/pytest_.py` and `./check/coverage_.py` for me locally.

Rather than adding more mocks, I think it is safe to remove these tests, since they are redundant with [`gss.superstaq_client_test.test_find_api_key`](https://github.com/Infleqtion/client-superstaq/blob/9779e5524b5b874d460608d9987979ca0bce85b9/general-superstaq/general_superstaq/superstaq_client_test.py#L702).

Also: nit bugfix in `check_utils.get_file_parser`, which caused the [default `--exclude` arguments](https://github.com/Infleqtion/client-superstaq/blob/9779e5524b5b874d460608d9987979ca0bce85b9/check/pytest_.py#L9-L13) to `check/pytest_.py` to yield the [`parsed_args` object](https://github.com/Infleqtion/client-superstaq/blob/9779e5524b5b874d460608d9987979ca0bce85b9/general-superstaq/general_superstaq/check/pytest_.py#L57)
```
Namespace(revisions=None, exclude=['c', 'i', 'r', 'q', '-', 's', 'u', 'p', 'e', 'r', 's', 't', 'a', 'q', '/', 'e', 'x', 'a', 'm', 'p', 'l', 'e', 's', '/', 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e', '_', 'e', 's', 't', 'i', 'm', 'a', 't', 'e', '.', 'i', 'p', 'y', 'n', 'b', 'd', 'o', 'c', 's', '/', 's', 'o', 'u', 'r', 'c', 'e', '/', 'a', 'p', 'p', 's', '/', '*', 'd', 'o', 'c', 's', '/', 's', 'o', 'u', 'r', 'c', 'e', '/', 'g', 'e', 't', '_', 's', 't', 'a', 'r', 't', 'e', 'd', '/', '*', 'd', 'o', 'c', 's', '/', 's', 'o', 'u', 'r', 'c', 'e', '/', 'o', 'p', 't', 'i', 'm', 'i', 'z', 'a', 't', 'i', 'o', 'n', 's', '/', 'i', 'b', 'm', '/', 'i', 'b', 'm', 'q', '_', 'c', 'o', 'm', 'p', 'i', 'l', 'e', '_', 'c', 's', 's', '.', 'i', 'p', 'y', 'n', 'b', 'q', 'i', 's', 'k', 'i', 't', '-', 's', 'u', 'p', 'e', 'r', 's', 't', 'a', 'q', '/', 'e', 'x', 'a', 'm', 'p', 'l', 'e', 's', '/', 'u', 'c', 'h', 'i', 'c', 'a', 'g', 'o', '_', 'w', 'o', 'r', 'k', 's', 'h', 'o', 'p', '.', 'i', 'p', 'y', 'n', 'b'], notebook=False, integration=False, enable_socket=False, files=[])
```
rather than
```
Namespace(revisions=None, exclude=['cirq-superstaq/examples/resource_estimate.ipynb', 'docs/source/apps/*', 'docs/source/get_started/*', 'docs/source/optimizations/ibm/ibmq_compile_css.ipynb', 'qiskit-superstaq/examples/uchicago_workshop.ipynb'], notebook=False, integration=False, enable_socket=False, files=[])
```