### PR TITLE
add checks-pyproject.toml to gss package_data

### DIFF
--- a/general-superstaq/pyproject.toml
+++ b/general-superstaq/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 include = ["general_superstaq*"]
 
 [tool.setuptools.package-data]
-general_superstaq = ["py.typed"]
+general_superstaq = ["py.typed", "check/checks-pyproject.toml"]
 
 [tool.setuptools.dynamic.version]
 attr = "general_superstaq._version.__version__"


### PR DESCRIPTION
otherwise check/configs_.py will fail if gss was pulled from pypi