### PR TITLE
pass config file path to black

### DIFF
--- a/general-superstaq/general_superstaq/check/format_.py
+++ b/general-superstaq/general_superstaq/check/format_.py
@@ -55,10 +55,10 @@ def run(
 
     args_to_pass_isort += ["--resolve-all-configs", f"--config-root={check_utils.root_dir}"]
     returncode_isort = 0
-    # subprocess.call(
-    #     ["python", "-m", "isort", *files, *diff_check_args, *args_to_pass_isort],
-    #     cwd=check_utils.root_dir,
-    # )
+    subprocess.call(
+        ["python", "-m", "isort", *files, *diff_check_args, *args_to_pass_isort],
+        cwd=check_utils.root_dir,
+    )
 
     if returncode_black == 1 or returncode_isort == 1:
         # some files should be reformatted, but there don't seem to be any bona fide errors

--- a/general-superstaq/general_superstaq/check/format_.py
+++ b/general-superstaq/general_superstaq/check/format_.py
@@ -54,8 +54,7 @@ def run(
         return returncode_black
 
     args_to_pass_isort += ["--resolve-all-configs", f"--config-root={check_utils.root_dir}"]
-    returncode_isort = 0
-    subprocess.call(
+    returncode_isort = subprocess.call(
         ["python", "-m", "isort", *files, *diff_check_args, *args_to_pass_isort],
         cwd=check_utils.root_dir,
     )

--- a/general-superstaq/general_superstaq/check/format_.py
+++ b/general-superstaq/general_superstaq/check/format_.py
@@ -41,12 +41,12 @@ def run(
     if not files:
         return 0
 
-    black_args = ["--config", "pyproject.toml"]
-    if not parsed_args.apply:
-        black_args += ["--diff", "--check"]
+    diff_check_args = ["--diff", "--check"] if not parsed_args.apply else []
 
+    args_to_pass_black = ["--config", "pyproject.toml"]
     returncode_black = subprocess.call(
-        ["python", "-m", "black", *files, *black_args], cwd=check_utils.root_dir
+        ["python", "-m", "black", *files, *diff_check_args, *args_to_pass_black],
+        cwd=check_utils.root_dir,
     )
 
     if returncode_black > 1:

--- a/general-superstaq/general_superstaq/check/format_.py
+++ b/general-superstaq/general_superstaq/check/format_.py
@@ -41,9 +41,12 @@ def run(
     if not files:
         return 0
 
-    diff_check_args = ["--diff", "--check"] if not parsed_args.apply else []
+    black_args = ["--config", "pyproject.toml"]
+    if not parsed_args.apply:
+        black_args += ["--diff", "--check"]
+
     returncode_black = subprocess.call(
-        ["python", "-m", "black", *files, *diff_check_args], cwd=check_utils.root_dir
+        ["python", "-m", "black", *files, *black_args], cwd=check_utils.root_dir
     )
 
     if returncode_black > 1:
@@ -51,10 +54,11 @@ def run(
         return returncode_black
 
     args_to_pass_isort += ["--resolve-all-configs", f"--config-root={check_utils.root_dir}"]
-    returncode_isort = subprocess.call(
-        ["python", "-m", "isort", *files, *diff_check_args, *args_to_pass_isort],
-        cwd=check_utils.root_dir,
-    )
+    returncode_isort = 0
+    # subprocess.call(
+    #     ["python", "-m", "isort", *files, *diff_check_args, *args_to_pass_isort],
+    #     cwd=check_utils.root_dir,
+    # )
 
     if returncode_black == 1 or returncode_isort == 1:
         # some files should be reformatted, but there don't seem to be any bona fide errors


### PR DESCRIPTION
by default black will look for config files in the common parent directory of all the files it's checking. this causes `check/format_.py <files>` (or `check/format_.py -i`) to break if all the (modified) files were in the same subdirectory, because e.g. it will use `cirq-superstaq/pyproject.toml` instead of `./pyproject.toml`