### PR TITLE
support for qiskit-terra 0.25.0

### DIFF
--- a/cirq-superstaq/example-requirements.txt
+++ b/cirq-superstaq/example-requirements.txt
@@ -1,2 +1,2 @@
 notebook~=6.4.12
-qiskit-terra~=0.24.2
+qiskit-terra>=0.24.2

--- a/qiskit-superstaq/qiskit_superstaq/custom_gates.py
+++ b/qiskit-superstaq/qiskit_superstaq/custom_gates.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
-import qiskit
+import qiskit.visualization
 
 
 class AceCR(qiskit.circuit.Gate):
@@ -270,7 +270,10 @@ class ParallelGates(qiskit.circuit.Gate):
         return np.asarray(mat, dtype=dtype)
 
     def __str__(self) -> str:
-        args = ", ".join(gate.qasm() for gate in self.component_gates)
+        def _param_str(gate: qiskit.circuit.Instruction) -> str:
+            return qiskit.visualization.text.get_param_str(gate, "text")
+
+        args = ", ".join(f"{gate.name}{_param_str(gate)}" for gate in self.component_gates)
         return f"ParallelGates({args})"
 
 

--- a/qiskit-superstaq/qiskit_superstaq/custom_gates_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/custom_gates_test.py
@@ -27,17 +27,14 @@ def test_acecr() -> None:
     gate = qss.AceCR("+-")
     assert repr(gate) == "qss.AceCR()"
     assert str(gate) == "AceCR"
-    assert gate.qasm() == "acecr(pi/2)"
 
     gate = qss.AceCR("-+", label="label")
     assert repr(gate) == "qss.AceCR(rads=-1.5707963267948966, label='label')"
     assert str(gate) == "AceCR(-0.5π)"
-    assert gate.qasm() == "acecr(-pi/2)"
 
     gate = qss.AceCR("-+", sandwich_rx_rads=np.pi / 2)
     assert repr(gate) == "qss.AceCR(rads=-1.5707963267948966, sandwich_rx_rads=1.5707963267948966)"
     assert str(gate) == "AceCR(-0.5π)|RXGate(pi/2)|"
-    assert gate.qasm() == "acecr_rx(-pi/2,pi/2)"
 
     gate = qss.AceCR("-+", sandwich_rx_rads=np.pi / 2, label="label")
     _check_gate_definition(gate)
@@ -46,7 +43,6 @@ def test_acecr() -> None:
         == "qss.AceCR(rads=-1.5707963267948966, sandwich_rx_rads=1.5707963267948966, label='label')"
     )
     assert str(gate) == "AceCR(-0.5π)|RXGate(pi/2)|"
-    assert gate.qasm() == "acecr_rx(-pi/2,pi/2)"
 
     with pytest.raises(ValueError, match="Polarity must be"):
         _ = qss.AceCR("++")
@@ -99,7 +95,7 @@ def test_parallel_gates() -> None:
         qss.AceCR("+-"),
         qiskit.circuit.library.RXGate(1.23),
     )
-    assert str(gate) == "ParallelGates(acecr(pi/2), rx(1.23))"
+    assert str(gate) == "ParallelGates(acecr(π/2), rx(1.23))"
     _check_gate_definition(gate)
 
     # confirm gates are applied to disjoint qubits

--- a/qiskit-superstaq/qiskit_superstaq/serialization.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization.py
@@ -159,7 +159,7 @@ def deserialize_circuits(serialized_circuits: str) -> List[qiskit.QuantumCircuit
             circuits = qiskit.qpy.load(buf)
 
     except Exception as e:
-        qpy_version_match = re.match(b"QISKIT(.)", buf.getvalue())
+        qpy_version_match = re.match(b"QISKIT([\x00-\xff])", buf.getvalue())
         circuits_qpy_version = ord(qpy_version_match.group(1)) if qpy_version_match else 0
         if circuits_qpy_version > qiskit.qpy.common.QPY_VERSION:
             # If the circuit was serialized with a newer version of QPY, that's probably what caused


### PR DESCRIPTION
fixes a test and removes every instance of `gate.qasm()` (which is now deprecated)