### PR TITLE
Delete `convert_qubo_to_model` in `qubo.py`

### DIFF
--- a/general-superstaq/general_superstaq/qubo.py
+++ b/general-superstaq/general_superstaq/qubo.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, Tuple
 
-import qubovert as qv
-
 import general_superstaq as gss
 
 
@@ -15,18 +13,3 @@ def read_json_qubo_result(json_dict: Dict[str, str]) -> List[Dict[Tuple[int], in
         A `numpy.recarray` containing the results of the optimization.
     """
     return gss.serialization.deserialize(json_dict["solution"])
-
-
-def convert_qubo_to_model(qubo: qv.QUBO) -> gss.QuboModel:
-    """Takes in a qubovert QUBO and converts it to the format required by the /qubo endpoint API.
-
-    Args:
-        qubo: A `qubovert.QUBO` object.
-
-    Returns:
-        An equivalent qubo represented as a nested list of dictionaries.
-    """
-    model: gss.QuboModel = []
-    for key, value in qubo.items():
-        model.append({"keys": [str(variable) for variable in key], "value": value})
-    return model

--- a/general-superstaq/general_superstaq/qubo_test.py
+++ b/general-superstaq/general_superstaq/qubo_test.py
@@ -1,6 +1,4 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
-import qubovert as qv
-
 import general_superstaq as gss
 
 
@@ -11,13 +9,3 @@ def test_read_json_qubo_result() -> None:
     server_return = {"solution": gss.serialization.serialize(deserialized_return)}
 
     assert repr(gss.qubo.read_json_qubo_result(server_return)) == repr(deserialized_return)
-
-
-def test_convert_qubo_to_model() -> None:
-    example_qubo = qv.QUBO({(0,): 1.0, (1,): 1.0, (0, 1): -2.0})
-    qubo_model = [
-        {"keys": ["0"], "value": 1.0},
-        {"keys": ["1"], "value": 1.0},
-        {"keys": ["0", "1"], "value": -2.0},
-    ]
-    assert gss.qubo.convert_qubo_to_model(example_qubo) == qubo_model


### PR DESCRIPTION
In `qubo.py`, the `convert_qubo_to_model` function previously was used to serialize a qubo before sending it in as a request. However, after finishing #681, there is no need for this function anymore - removed for cleanliness.