### PR TITLE
Update tutorials with `"dry-run"`

### DIFF
--- a/docs/source/get_started/access_info/access_info_css.ipynb
+++ b/docs/source/get_started/access_info/access_info_css.ipynb
@@ -245,7 +245,7 @@
     "# Submitting the circuit to the IBM Q QASM Simulator\n",
     "job = service.create_job(\n",
     "    circuit=circuit, repetitions=100, method=\"dry-run\", target=\"ibmq_qasm_simulator\"\n",
-    ")  # Specify \"dry-run\" as the method to run Superstaq simulation"
+    ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
    ]
   },
   {

--- a/docs/source/get_started/access_info/access_info_css.ipynb
+++ b/docs/source/get_started/access_info/access_info_css.ipynb
@@ -242,8 +242,10 @@
     "    cirq.measure(qubits[1]),\n",
     ")\n",
     "\n",
-    "# submitting the circuit to the IBM Q QASM Simulator\n",
-    "job = service.create_job(circuit=circuit, repetitions=100, target=\"ibmq_qasm_simulator\")"
+    "# Submitting the circuit to the IBM Q QASM Simulator\n",
+    "job = service.create_job(\n",
+    "    circuit=circuit, repetitions=100, method=\"dry-run\", target=\"ibmq_qasm_simulator\"\n",
+    ")  # Specify \"dry-run\" as the method to run Superstaq simulation"
    ]
   },
   {

--- a/docs/source/get_started/access_info/access_info_qss.ipynb
+++ b/docs/source/get_started/access_info/access_info_qss.ipynb
@@ -233,7 +233,7 @@
     "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "job = backend.run(\n",
     "    qc, method=\"dry-run\", shots=100\n",
-    ")  # Specify \"dry-run\" as the method to run Superstaq simulation"
+    ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
    ]
   },
   {

--- a/docs/source/get_started/access_info/access_info_qss.ipynb
+++ b/docs/source/get_started/access_info/access_info_qss.ipynb
@@ -229,9 +229,11 @@
     "qc.cx(0, 1)\n",
     "qc.measure([0, 1], [0, 1])\n",
     "\n",
-    "# submitting the circuit to the IBM Q QASM Simulator\n",
+    "# Submitting the circuit to the IBM Q QASM Simulator\n",
     "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-    "job = backend.run(qc, shots=100)"
+    "job = backend.run(\n",
+    "    qc, method=\"dry-run\", shots=100\n",
+    ")  # Specify \"dry-run\" as the method to run Superstaq simulation"
    ]
   },
   {

--- a/docs/source/get_started/basics/basics_css.ipynb
+++ b/docs/source/get_started/basics/basics_css.ipynb
@@ -162,7 +162,7 @@
     }
    ],
    "source": [
-    "# Specify \"dry-run\" as the method to run Superstaq simulation\n",
+    "# Specify \"dry-run\" as the method to submit & run a Superstaq simulation\n",
     "job = service.create_job(\n",
     "    circuit=circuit, repetitions=100, method=\"dry-run\", target=\"ibmq_qasm_simulator\"\n",
     ")\n",
@@ -173,7 +173,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/get_started/basics/basics_css.ipynb
+++ b/docs/source/get_started/basics/basics_css.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "617fcaf5",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "c56ba8eb",
    "metadata": {},
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "c875069a",
    "metadata": {},
    "outputs": [],
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "60209f85",
    "metadata": {},
    "outputs": [
@@ -138,12 +138,16 @@
    "metadata": {},
    "source": [
     "## Submit your circuit and view results\n",
-    "Finally, we can submit our circuit to the desired device and view the results of our job. Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
+    "Finally, we can submit our circuit to the desired device (by specifying `target=`) and view the results of our job. \n",
+    "\n",
+    "For the purposes of this tutorial, we will instruct Superstaq to simulate the circuit to the desired device backend by providing the `\"dry-run\"` method parameter, a feature that is available to all users including free-trial users. \n",
+    "\n",
+    "Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a4c28933",
    "metadata": {
     "scrolled": true
@@ -153,12 +157,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'11': 49.0, '00': 51.0}\n"
+      "{'00': 45, '11': 55}\n"
      ]
     }
    ],
    "source": [
-    "job = service.create_job(circuit=circuit, repetitions=100, target=\"ibmq_qasm_simulator\")\n",
+    "# Specify \"dry-run\" as the method to run Superstaq simulation\n",
+    "job = service.create_job(\n",
+    "    circuit=circuit, repetitions=100, method=\"dry-run\", target=\"ibmq_qasm_simulator\"\n",
+    ")\n",
     "result = job.counts()\n",
     "print(result)"
    ]
@@ -166,7 +173,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -180,7 +187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.9.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/get_started/basics/basics_css.ipynb
+++ b/docs/source/get_started/basics/basics_css.ipynb
@@ -140,9 +140,9 @@
     "## Submit your circuit and view results\n",
     "Finally, we can submit our circuit to the desired device (by specifying `target=`) and view the results of our job. \n",
     "\n",
-    "For the purposes of this tutorial, we will instruct Superstaq to simulate the circuit to the desired device backend by providing the `\"dry-run\"` method parameter, a feature that is available to all users including free-trial users. \n",
+    "Here, we will simulate for [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access, compile, and simulate to many other devices via Superstaq!\n",
     "\n",
-    "Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
+    "To perform the simulation, we must instruct Superstaq to simulate the circuit to the desired target backend by passing `\"dry-run\"` as the `method`. Simulation via `\"dry-run\"` is a feature that is available to all users including free-trial users! Finally, we can retrieve the results of the job, the counts, by calling `counts()`."
    ]
   },
   {
@@ -164,7 +164,10 @@
    "source": [
     "# Specify \"dry-run\" as the method to submit & run a Superstaq simulation\n",
     "job = service.create_job(\n",
-    "    circuit=circuit, repetitions=100, method=\"dry-run\", target=\"ibmq_qasm_simulator\"\n",
+    "    circuit=circuit,\n",
+    "    method=\"dry-run\",\n",
+    "    target=\"ibmq_qasm_simulator\",\n",
+    "    repetitions=100,\n",
     ")\n",
     "result = job.counts()\n",
     "print(result)"

--- a/docs/source/get_started/basics/basics_qss.ipynb
+++ b/docs/source/get_started/basics/basics_qss.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "9eaec3ca",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "c56ba8eb",
    "metadata": {},
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "c875069a",
    "metadata": {},
    "outputs": [],
@@ -106,7 +106,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "60209f85",
    "metadata": {},
    "outputs": [
@@ -117,7 +117,7 @@
        "<Figure size 454.517x284.278 with 1 Axes>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,12 +137,16 @@
    "metadata": {},
    "source": [
     "## Submit your circuit and view results\n",
-    "Finally, we can submit our circuit to the desired device and view the results of our job. Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
+    "Finally, we can submit our circuit to the desired device (by calling `get_backend()`) and view the results of our job. \n",
+    "\n",
+    "For the purposes of this tutorial, we will instruct Superstaq to simulate the circuit to the desired device backend by providing the `\"dry-run\"` method parameter, a feature that is available to all users including free-trial users. \n",
+    "\n",
+    "Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "a4c28933",
    "metadata": {
     "scrolled": false
@@ -152,13 +156,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'11': 49.0, '00': 51.0}\n"
+      "{'00': 49, '11': 51}\n"
      ]
     }
    ],
    "source": [
     "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-    "job = backend.run(qc, shots=100)\n",
+    "\n",
+    "# Specify \"dry-run\" as the method to run Superstaq simulation\n",
+    "job = backend.run(qc, shots=100, method=\"dry-run\")\n",
     "result = job.result().get_counts()\n",
     "print(result)"
    ]
@@ -166,7 +172,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -180,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.9.16"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/source/get_started/basics/basics_qss.ipynb
+++ b/docs/source/get_started/basics/basics_qss.ipynb
@@ -137,7 +137,7 @@
    "metadata": {},
    "source": [
     "## Submit your circuit and view results\n",
-    "Finally, we can submit our circuit to the desired device (by calling `get_backend()`) and view the results of our job. \n",
+    "Finally, we can submit our circuit to the desired device (by calling `get_backend`) and view the results of our job. \n",
     "\n",
     "For the purposes of this tutorial, we will instruct Superstaq to simulate the circuit to the desired device backend by providing the `\"dry-run\"` method parameter, a feature that is available to all users including free-trial users. \n",
     "\n",
@@ -163,7 +163,7 @@
    "source": [
     "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "\n",
-    "# Specify \"dry-run\" as the method to run Superstaq simulation\n",
+    "# Specify \"dry-run\" as the method to submit & run a Superstaq simulation\n",
     "job = backend.run(qc, shots=100, method=\"dry-run\")\n",
     "result = job.result().get_counts()\n",
     "print(result)"
@@ -172,7 +172,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/source/get_started/basics/basics_qss.ipynb
+++ b/docs/source/get_started/basics/basics_qss.ipynb
@@ -139,9 +139,9 @@
     "## Submit your circuit and view results\n",
     "Finally, we can submit our circuit to the desired device (by calling `get_backend`) and view the results of our job. \n",
     "\n",
-    "For the purposes of this tutorial, we will instruct Superstaq to simulate the circuit to the desired device backend by providing the `\"dry-run\"` method parameter, a feature that is available to all users including free-trial users. \n",
+    "Here, we will simulate for [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access, compile, and simulate to many other devices via Superstaq!\n",
     "\n",
-    "Here, we use [IBM's QASM simulator](https://quantum-computing.ibm.com/lab/docs/iql/manage/simulator), but you can access many other devices via Superstaq!"
+    "To perform the simulation, we must instruct Superstaq to simulate the circuit to the desired target backend by passing `\"dry-run\"` as the `method`. Simulation via `\"dry-run\"` is a feature that is available to all users including free-trial users! Finally, we can retrieve the results of the job, the counts, by calling `result().get_counts()`."
    ]
   },
   {
@@ -164,7 +164,7 @@
     "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "\n",
     "# Specify \"dry-run\" as the method to submit & run a Superstaq simulation\n",
-    "job = backend.run(qc, shots=100, method=\"dry-run\")\n",
+    "job = backend.run(qc, method=\"dry-run\", shots=100)\n",
     "result = job.result().get_counts()\n",
     "print(result)"
    ]


### PR DESCRIPTION
Addresses most of https://github.com/Infleqtion/client-superstaq/issues/696 by allowing free-trial users to run the notebooks for now. 

The qss notebook requires https://github.com/Infleqtion/server-superstaq/pull/2631