### PR TITLE
Update `build-system.requirements` to enforce newer versions of `setuptools` and `pip`

### DIFF
--- a/cirq-superstaq/pyproject.toml
+++ b/cirq-superstaq/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 homepage = "https://github.com/Infleqtion/client-superstaq"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64.0.0", "pip>=23.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/general-superstaq/dev-requirements.txt
+++ b/general-superstaq/dev-requirements.txt
@@ -5,6 +5,7 @@ flake8-type-checking>=2.1.0
 isort[colors]>=5.10.1
 mypy>=1.0.0
 nbmake>=1.3.0
+pip>=23.0.0
 pylint>=2.15.0
 pytest>=6.2.5
 pytest-cov>=2.11.1

--- a/general-superstaq/dev-requirements.txt
+++ b/general-superstaq/dev-requirements.txt
@@ -5,7 +5,6 @@ flake8-type-checking>=2.1.0
 isort[colors]>=5.10.1
 mypy>=1.0.0
 nbmake>=1.3.0
-pip>=23.0.0
 pylint>=2.15.0
 pytest>=6.2.5
 pytest-cov>=2.11.1

--- a/general-superstaq/pyproject.toml
+++ b/general-superstaq/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 homepage = "https://github.com/Infleqtion/client-superstaq"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64.0.0", "pip>=23.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/qiskit-superstaq/pyproject.toml
+++ b/qiskit-superstaq/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 homepage = "https://github.com/Infleqtion/client-superstaq"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64.0.0", "pip>=23.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]

--- a/supermarq-benchmarks/pyproject.toml
+++ b/supermarq-benchmarks/pyproject.toml
@@ -13,7 +13,7 @@ dynamic = ["version", "dependencies", "optional-dependencies"]
 homepage = "https://github.com/Infleqtion/client-superstaq"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64.0.0", "pip>=23.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
fixes #714

...in theory.  Does not work at the moment, for reasons unknown.  `build-system.requires` seems to be ignored.