### PR TITLE
Remove token setting methods from the client interface

### DIFF
--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -11,7 +11,6 @@ jobs:
     name: Pytest integration check
     env:
       SUPERSTAQ_API_KEY : ${{ secrets.SUPERSTAQ_API_KEY }}
-      TEST_USER_IBMQ_TOKEN : ${{ secrets.TEST_USER_IBMQ_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -1,13 +1,10 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
 
-
-import os
-
 import cirq
 import general_superstaq as gss
 import pytest
-from general_superstaq import ResourceEstimate, SuperstaqServerException
+from general_superstaq import ResourceEstimate
 
 import cirq_superstaq as css
 
@@ -135,18 +132,6 @@ def test_get_resource_estimate(service: css.Service) -> None:
     resource_estimates = service.resource_estimate(circuits, "ss_unconstrained_simulator")
 
     assert resource_estimates == [ResourceEstimate(2, 1, 3), ResourceEstimate(2, 2, 4)]
-
-
-def test_ibmq_set_token(service: css.Service) -> None:
-    try:
-        ibmq_token = os.environ["TEST_USER_IBMQ_TOKEN"]
-    except KeyError as key:
-        raise KeyError(f"To run the integration tests, please export to {key} a valid IBMQ token")
-
-    assert service.ibmq_set_token(ibmq_token) == "Your IBMQ account token has been updated"
-
-    with pytest.raises(SuperstaqServerException, match="IBMQ token is invalid."):
-        assert service.ibmq_set_token("INVALID_TOKEN")
 
 
 def test_get_targets(service: css.Service) -> None:

--- a/general-superstaq/general_superstaq/service.py
+++ b/general-superstaq/general_superstaq/service.py
@@ -145,28 +145,6 @@ class Service:
         """
         return self._client.submit_qubo(qubo, target, repetitions, method, max_solutions)
 
-    def ibmq_set_token(self, token: str) -> str:
-        """Sets IBMQ token field.
-
-        Args:
-            token: IBMQ token string.
-
-        Returns:
-            String containing status of update (whether or not it failed).
-        """
-        return self._client.ibmq_set_token({"ibmq_token": token})
-
-    def cq_set_token(self, token: str) -> str:
-        """Sets CQ token field.
-
-        Args:
-            token: CQ token string.
-
-        Returns:
-            String containing status of update (whether or not it failed).
-        """
-        return self._client.cq_set_token({"cq_token": token})
-
     def aqt_upload_configs(self, pulses: Any, variables: Any) -> str:
         """Uploads configs for AQT.
 

--- a/general-superstaq/general_superstaq/service_test.py
+++ b/general-superstaq/general_superstaq/service_test.py
@@ -109,28 +109,6 @@ def test_submit_qubo(
 
 
 @mock.patch(
-    "general_superstaq.superstaq_client._SuperstaqClient.post_request",
-    return_value="Your IBMQ account token has been updated",
-)
-def test_ibmq_set_token(
-    mock_post_request: mock.MagicMock,
-) -> None:
-    service = gss.service.Service(remote_host="http://example.com", api_key="key")
-    assert service.ibmq_set_token("valid token") == "Your IBMQ account token has been updated"
-
-
-@mock.patch(
-    "general_superstaq.superstaq_client._SuperstaqClient.post_request",
-    return_value="Your CQ account token has been updated",
-)
-def test_cq_set_token(
-    mock_post_request: mock.MagicMock,
-) -> None:
-    service = gss.service.Service(remote_host="http://example.com", api_key="key")
-    assert service.cq_set_token("valid token") == "Your CQ account token has been updated"
-
-
-@mock.patch(
     "general_superstaq.superstaq_client._SuperstaqClient.aqt_upload_configs",
     return_value="Your AQT configuration has been updated",
 )

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -579,28 +579,6 @@ class _SuperstaqClient:
         }
         return self.post_request("/target_info", json_dict)
 
-    def ibmq_set_token(self, json_dict: Dict[str, str]) -> str:
-        """Makes a POST request to Superstaq API to set IBMQ token field in database.
-
-        Args:
-            json_dict: Dictionary with IBMQ token string entry.
-
-        Returns:
-            The response as a string.
-        """
-        return self.post_request("/ibmq_token", json_dict)
-
-    def cq_set_token(self, json_dict: Dict[str, str]) -> str:
-        """Makes a POST request to Superstaq API to set CQ token field in database.
-
-        Args:
-            json_dict: Dictionary with CQ token string entry.
-
-        Returns:
-            The response as a string.
-        """
-        return self.post_request("/cq_token", json_dict)
-
     def aqt_upload_configs(self, aqt_configs: Dict[str, str]) -> str:
         """Makes a POST request to Superstaq API to upload configurations.
 

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -710,44 +710,6 @@ def test_superstaq_client_dfe(mock_post: mock.MagicMock) -> None:
 
 
 @mock.patch("requests.post")
-def test_superstaq_client_ibmq_set_token(mock_post: mock.MagicMock) -> None:
-    client = gss.superstaq_client._SuperstaqClient(
-        client_name="general-superstaq",
-        remote_host="http://example.com",
-        api_key="to_my_heart",
-    )
-
-    client.ibmq_set_token({"ibmq_token": "token"})
-
-    expected_json = {"ibmq_token": "token"}
-    mock_post.assert_called_with(
-        f"http://example.com/{API_VERSION}/ibmq_token",
-        headers=EXPECTED_HEADERS,
-        json=expected_json,
-        verify=False,
-    )
-
-
-@mock.patch("requests.post")
-def test_superstaq_client_cq_set_token(mock_post: mock.MagicMock) -> None:
-    client = gss.superstaq_client._SuperstaqClient(
-        client_name="general-superstaq",
-        remote_host="http://example.com",
-        api_key="to_my_heart",
-    )
-
-    client.cq_set_token({"cq_token": "token"})
-
-    expected_json = {"cq_token": "token"}
-    mock_post.assert_called_with(
-        f"http://example.com/{API_VERSION}/cq_token",
-        headers=EXPECTED_HEADERS,
-        json=expected_json,
-        verify=False,
-    )
-
-
-@mock.patch("requests.post")
 def test_superstaq_client_aqt_upload_configs(mock_post: mock.MagicMock) -> None:
     client = gss.superstaq_client._SuperstaqClient(
         client_name="general-superstaq",

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -1,13 +1,11 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
 
-import os
-
 import general_superstaq as gss
 import numpy as np
 import pytest
 import qiskit
-from general_superstaq import ResourceEstimate, SuperstaqServerException
+from general_superstaq import ResourceEstimate
 
 import qiskit_superstaq as qss
 
@@ -20,18 +18,6 @@ def provider() -> qss.SuperstaqProvider:
 def test_backends(provider: qss.SuperstaqProvider) -> None:
     result = provider.backends()
     assert provider.get_backend("ibmq_qasm_simulator") in result
-
-
-def test_ibmq_set_token(provider: qss.SuperstaqProvider) -> None:
-    try:
-        ibmq_token = os.environ["TEST_USER_IBMQ_TOKEN"]
-    except KeyError as key:
-        raise KeyError(f"To run the integration tests, please export to {key} a valid IBMQ token")
-
-    assert provider.ibmq_set_token(ibmq_token) == "Your IBMQ account token has been updated"
-
-    with pytest.raises(SuperstaqServerException, match="IBMQ token is invalid."):
-        assert provider.ibmq_set_token("INVALID_TOKEN")
 
 
 def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:


### PR DESCRIPTION
These don't actually do anything, and can be safely removed.