### PR TITLE
revert addition of "device" attribute to serialized circuits

### DIFF
--- a/cirq-superstaq/cirq_superstaq/serialization.py
+++ b/cirq-superstaq/cirq_superstaq/serialization.py
@@ -1,4 +1,3 @@
-import json
 from typing import List, Sequence, Union
 
 import cirq
@@ -22,16 +21,7 @@ def serialize_circuits(
     Returns:
         A string representing the serialized circuit(s).
     """
-    dt = json.loads(cirq.to_json(circuits))
-    if isinstance(dt, list):
-        for circuit_dt in dt:
-            if "device" not in circuit_dt:
-                circuit_dt["device"] = {"cirq_type": "_UnconstrainedDevice"}
-    else:
-        if "device" not in dt:
-            dt["device"] = {"cirq_type": "_UnconstrainedDevice"}
-
-    return json.dumps(dt)
+    return cirq.to_json(circuits)
 
 
 def deserialize_circuits(serialized_circuits: str) -> List[cirq.Circuit]:

--- a/cirq-superstaq/cirq_superstaq/serialization_test.py
+++ b/cirq-superstaq/cirq_superstaq/serialization_test.py
@@ -1,6 +1,4 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
-from unittest import mock
-
 import cirq
 
 import cirq_superstaq as css
@@ -15,26 +13,6 @@ def test_serialization() -> None:
     assert css.serialization.deserialize_circuits(serialized_circuit) == [circuit]
 
     circuits = [circuit, circuit]
-    serialized_circuits = css.serialization.serialize_circuits(circuits)
-    assert isinstance(serialized_circuits, str)
-    assert css.serialization.deserialize_circuits(serialized_circuits) == circuits
-
-
-@mock.patch("cirq.to_json")
-def test_removed_device_circuit_atrribute(mock_cirq_to_json: mock.MagicMock) -> None:
-    mock_cirq_to_json.return_value = '{\n  "cirq_type": "Circuit",\n  "moments": []\n}'
-
-    circuit = cirq.Circuit()
-
-    serialized_circuit = css.serialization.serialize_circuits(circuit)
-    assert isinstance(serialized_circuit, str)
-    assert css.serialization.deserialize_circuits(serialized_circuit) == [circuit]
-
-    circuits = [circuit, circuit]
-    mock_cirq_to_json.return_value = (
-        '[\n  {\n    "cirq_type": "Circuit",\n    "moments": []\n  },\n  {\n    '
-        '"cirq_type": "Circuit",\n    "moments": []\n  }\n]'
-    )
     serialized_circuits = css.serialization.serialize_circuits(circuits)
     assert isinstance(serialized_circuits, str)
     assert css.serialization.deserialize_circuits(serialized_circuits) == circuits


### PR DESCRIPTION
reverts https://github.com/Infleqtion/cirq-superstaq/pull/241 (which at the time was necessary because we supported `cirq<=0.14.*`)