### PR TITLE
Handle float counts + warn users

### DIFF
--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -58,7 +58,9 @@ def _to_matrix_gate(matrix: npt.ArrayLike) -> cirq.MatrixGate:
 
 
 def counts_to_results(
-    counter: Dict[str, int], circuit: cirq.AbstractCircuit, param_resolver: cirq.ParamResolver
+    counter: Union[Dict[str, int], Dict[str, float]],
+    circuit: cirq.AbstractCircuit,
+    param_resolver: cirq.ParamResolver,
 ) -> cirq.ResultDict:
     """Converts a `collections.Counter` to a `cirq.ResultDict`.
 
@@ -91,6 +93,17 @@ def counts_to_results(
         # Appends all the keys onto 'samples' list number-of-counts-in-the-key times
         # If collections.Counter({"01": 48, "11": 52}), [0, 1] is appended to 'samples` 48 times and
         # [1, 1] is appended to 'samples' 52 times
+        if int(counts_of_key) != counts_of_key:
+            print(
+                warnings.warn(
+                    "The raw counts are fractional due to measurement error mitigation; please use "
+                    "service.get_counts to see raw results.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            )
+
+        counts_of_key = int(counts_of_key)
         for _ in range(counts_of_key):
             samples.append(keys_as_list)
 

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -58,7 +58,7 @@ def _to_matrix_gate(matrix: npt.ArrayLike) -> cirq.MatrixGate:
 
 
 def counts_to_results(
-    counter: Union[Dict[str, int], Dict[str, float]],
+    counter: Mapping[str, float],
     circuit: cirq.AbstractCircuit,
     param_resolver: cirq.ParamResolver,
 ) -> cirq.ResultDict:

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -91,13 +91,10 @@ def counts_to_results(
         # If collections.Counter({"01": 48, "11": 52}), [0, 1] is appended to 'samples` 48 times and
         # [1, 1] is appended to 'samples' 52 times
         if int(counts_of_key) != counts_of_key:
-            print(
-                warnings.warn(
-                    "The raw counts are fractional due to measurement error mitigation; please use "
-                    "service.get_counts to see raw results.",
-                    UserWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "The raw counts are fractional due to measurement error mitigation; please use "
+                "service.get_counts to see raw results.",
+                stacklevel=2,
             )
 
         counts_of_key = int(counts_of_key)

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -81,8 +81,14 @@ def counts_to_results(
     samples: List[List[int]] = []
     if not all(counts == int(counts) for counts in counter.values()):
         warnings.warn(
-            "The raw counts are fractional due to measurement error mitigation; please use "
-            "service.get_counts to see raw results.",
+            "The raw counts contain fractional values due to measurement error mitigation; please "
+            "use service.get_counts to see raw results.",
+            stacklevel=2,
+        )
+    if not all(counts >= 0 for counts in counter.values()):
+        warnings.warn(
+            "The raw counts contain negative values due to measurement error mitigation; please "
+            "use service.get_counts to see raw results.",
             stacklevel=2,
         )
     for key, counts_of_key in counter.items():

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -58,7 +58,9 @@ def _to_matrix_gate(matrix: npt.ArrayLike) -> cirq.MatrixGate:
 
 
 def counts_to_results(
-    counter: Dict[str, float], circuit: cirq.AbstractCircuit, param_resolver: cirq.ParamResolver
+    counter: Union[Dict[str, int], Dict[str, float]],
+    circuit: cirq.AbstractCircuit,
+    param_resolver: cirq.ParamResolver,
 ) -> cirq.ResultDict:
     """Converts a `collections.Counter` to a `cirq.ResultDict`.
 

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -79,25 +79,21 @@ def counts_to_results(
     combine_key_names = "".join(measurement_key_names)
 
     samples: List[List[int]] = []
-    for key in counter.keys():
+    if not all(counts == int(counts) for counts in counter.values()):
+        warnings.warn(
+            "The raw counts are fractional due to measurement error mitigation; please use "
+            "service.get_counts to see raw results.",
+            stacklevel=2,
+        )
+    for key, counts_of_key in counter.items():
         # Combines the keys of the counter into a list. If key = "01", keys_as_list = [0, 1]
         keys_as_list: List[int] = list(map(int, key))
 
-        # Gets the number of counts of the key
-        # counter = collections.Counter({"01": 48, "11": 52})["01"] -> 48
-        counts_of_key = counter[key]
-
-        # Appends all the keys onto 'samples' list number-of-counts-in-the-key times
-        # If collections.Counter({"01": 48, "11": 52}), [0, 1] is appended to 'samples` 48 times and
-        # [1, 1] is appended to 'samples' 52 times
-        if int(counts_of_key) != counts_of_key:
-            warnings.warn(
-                "The raw counts are fractional due to measurement error mitigation; please use "
-                "service.get_counts to see raw results.",
-                stacklevel=2,
-            )
-
-        counts_of_key = int(counts_of_key)
+        # Gets execution counts per bitstring, e.g., collections.Counter({"01": 48, "11": 52})["01"]
+        # = 48. Per execution shot, appends bitstring to `samples` list. E.g., if counter is
+        # collections.Counter({"01": 48, "11": 52}), [0, 1] is appended 48 times and [1, 1] is
+        # appended 52 times.
+        counts_of_key = round(counts_of_key)
         for _ in range(counts_of_key):
             samples.append(keys_as_list)
 

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -80,11 +80,8 @@ def counts_to_results(
 
     samples: List[List[int]] = []
     for key in counter.keys():
-        keys_as_list: List[int] = []
-
         # Combines the keys of the counter into a list. If key = "01", keys_as_list = [0, 1]
-        for index in key:
-            keys_as_list.append(int(index))
+        keys_as_list: List[int] = list(map(int, key))
 
         # Gets the number of counts of the key
         # counter = collections.Counter({"01": 48, "11": 52})["01"] -> 48

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -58,9 +58,7 @@ def _to_matrix_gate(matrix: npt.ArrayLike) -> cirq.MatrixGate:
 
 
 def counts_to_results(
-    counter: Union[Dict[str, int], Dict[str, float]],
-    circuit: cirq.AbstractCircuit,
-    param_resolver: cirq.ParamResolver,
+    counter: Dict[str, float], circuit: cirq.AbstractCircuit, param_resolver: cirq.ParamResolver
 ) -> cirq.ResultDict:
     """Converts a `collections.Counter` to a `cirq.ResultDict`.
 

--- a/cirq-superstaq/cirq_superstaq/service_test.py
+++ b/cirq-superstaq/cirq_superstaq/service_test.py
@@ -68,9 +68,14 @@ def test_counts_to_results() -> None:
     )
     assert result.histogram(key="01") == collections.Counter({0: 50, 3: 50})
 
-    with pytest.warns(UserWarning, match="raw counts are fractional"):
+    with pytest.warns(UserWarning, match="raw counts contain fractional"):
         result = css.service.counts_to_results(
             {"00": 50.1, "11": 49.9}, circuit, cirq.ParamResolver({})
+        )
+
+    with pytest.warns(UserWarning, match="raw counts contain negative"):
+        result = css.service.counts_to_results(
+            {"00": -50.1, "11": 99.9}, circuit, cirq.ParamResolver({})
         )
 
 

--- a/cirq-superstaq/cirq_superstaq/service_test.py
+++ b/cirq-superstaq/cirq_superstaq/service_test.py
@@ -63,6 +63,16 @@ def test_counts_to_results() -> None:
     result = css.service.counts_to_results({"00": 50, "11": 50}, circuit, cirq.ParamResolver({}))
     assert result.histogram(key="01") == collections.Counter({0: 50, 3: 50})
 
+    result = css.service.counts_to_results(
+        {"00": 50.0, "11": 50.0}, circuit, cirq.ParamResolver({})
+    )
+    assert result.histogram(key="01") == collections.Counter({0: 50, 3: 50})
+
+    with pytest.warns(UserWarning, match="raw counts are fractional"):
+        result = css.service.counts_to_results(
+            {"00": 50.1, "11": 49.9}, circuit, cirq.ParamResolver({})
+        )
+
 
 def test_service_resolve_target() -> None:
     service = css.Service(api_key="key", default_target="ss_bar_qpu")

--- a/cirq-superstaq/cirq_superstaq/service_test.py
+++ b/cirq-superstaq/cirq_superstaq/service_test.py
@@ -72,11 +72,13 @@ def test_counts_to_results() -> None:
         result = css.service.counts_to_results(
             {"00": 50.1, "11": 49.9}, circuit, cirq.ParamResolver({})
         )
+        assert result.histogram(key="01") == collections.Counter({0: 50, 3: 50})
 
     with pytest.warns(UserWarning, match="raw counts contain negative"):
         result = css.service.counts_to_results(
             {"00": -50.1, "11": 99.9}, circuit, cirq.ParamResolver({})
         )
+        assert result.histogram(key="01") == collections.Counter({3: 100})
 
 
 def test_service_resolve_target() -> None:


### PR DESCRIPTION
Fixes #782.

This primarily handles getting counts like `{"01": 500.0, "10": 500.0}`, where they're already whole numbers. For `float` results more generally, I claim it's enough to warn users since we also offer `service.get_counts` as a public method, but I'm open to ideas about how else to address this.

(Seems like we can't get around `cirq.ResultDict` needing a list/array of results for the `measurements` param, and we can't append half or a quarter of an array element...)