### PR TITLE
Set timeout on Hilbert submission daily integration test to 5 minutes

### DIFF
--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       SUPERSTAQ_API_KEY : ${{ secrets.SUPERSTAQ_API_KEY }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.8

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -269,7 +269,7 @@ def test_submit_to_provider_simulators(target: str, service: css.Service) -> Non
     job = service.create_job(circuit=circuit, repetitions=1, target=target)
     assert job.counts() == {"11": 1}
 
-
+@pytest.mark.timeout(300)
 def test_submit_to_hilbert_qubit_sorting(service: css.Service) -> None:
     """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""
     target = "cq_hilbert_qpu"

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -269,6 +269,7 @@ def test_submit_to_provider_simulators(target: str, service: css.Service) -> Non
     job = service.create_job(circuit=circuit, repetitions=1, target=target)
     assert job.counts() == {"11": 1}
 
+
 @pytest.mark.timeout(300)
 def test_submit_to_hilbert_qubit_sorting(service: css.Service) -> None:
     """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -231,7 +231,7 @@ def test_submit_to_provider_simulators(target: str, provider: qss.SuperstaqProvi
     job = provider.get_backend(target).run(qc, shots=1)
     assert job.result().get_counts() == {"11": 1}
 
-
+@pytest.mark.timeout(300)
 def test_submit_to_hilbert_qubit_sorting(provider: qss.SuperstaqProvider) -> None:
     """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""
     backend = provider.get_backend("cq_hilbert_qpu")

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -231,6 +231,7 @@ def test_submit_to_provider_simulators(target: str, provider: qss.SuperstaqProvi
     job = provider.get_backend(target).run(qc, shots=1)
     assert job.result().get_counts() == {"11": 1}
 
+
 @pytest.mark.timeout(300)
 def test_submit_to_hilbert_qubit_sorting(provider: qss.SuperstaqProvider) -> None:
     """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""


### PR DESCRIPTION
Hotfix for now. We probably want to put this as a separate test longterm so a different issue will be made by the bot when the test fails.