### PR TITLE
Add tests using a custom IBMQ token

### DIFF
--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -31,6 +31,7 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_USER_IBMQ_TOKEN : ${{ secrets.TEST_USER_IBMQ_TOKEN }}
         with:
           filename: .github/integration-check-failure-issue.md
           update_existing: true

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
+import os
 
 import cirq
 import general_superstaq as gss
@@ -28,6 +29,21 @@ def test_ibmq_compile(service: css.Service) -> None:
     assert out.pulse_sequence is not None
 
     out = service.ibmq_compile(circuit, target="ibmq_lagos_qpu")
+    assert isinstance(out.circuit, cirq.Circuit)
+    assert out.pulse_sequence is not None
+
+
+def test_ibmq_compile_with_token() -> None:
+    service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
+    qubits = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        css.AceCRMinusPlus(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[1], qubits[2]),
+        css.AceCRMinusPlus(qubits[2], qubits[3]),
+    )
+
+    out = service.ibmq_compile(circuit, target="ibmq_perth_qpu")
+
     assert isinstance(out.circuit, cirq.Circuit)
     assert out.pulse_sequence is not None
 

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
+import os
 
 import general_superstaq as gss
 import numpy as np
@@ -32,6 +33,20 @@ def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
     assert isinstance(out.pulse_sequence, qiskit.pulse.Schedule)
 
     out = provider.ibmq_compile(qc, target="ibmq_lagos_qpu")
+    assert isinstance(out, qss.compiler_output.CompilerOutput)
+    assert isinstance(out.circuit, qiskit.QuantumCircuit)
+    assert isinstance(out.pulse_sequence, qiskit.pulse.Schedule)
+
+
+def test_ibmq_compile_with_token() -> None:
+    provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
+    qc = qiskit.QuantumCircuit(4)
+    qc.append(qss.AceCR("-+"), [0, 1])
+    qc.append(qss.AceCR("-+"), [1, 2])
+    qc.append(qss.AceCR("-+"), [2, 3])
+
+    out = provider.ibmq_compile(qc, target="ibmq_perth_qpu")
+
     assert isinstance(out, qss.compiler_output.CompilerOutput)
     assert isinstance(out.circuit, qiskit.QuantumCircuit)
     assert isinstance(out.pulse_sequence, qiskit.pulse.Schedule)


### PR DESCRIPTION
These tests make use of the TEST_USER_IBMQ_TOKEN that was already set up for testing the token setting methods that were removed.