### PR TITLE
fix incorrect line in checks-superstaq/pyproject.toml

### DIFF
--- a/checks-superstaq/pyproject.toml
+++ b/checks-superstaq/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "setuptools.build_meta"
 include = ["checks_superstaq*"]
 
 [tool.setuptools.package-data]
-general_superstaq = ["checks_superstaq/checks-pyproject.toml"]
+checks_superstaq = ["checks-pyproject.toml"]
 
 [tool.setuptools.dynamic.version]
 attr = "checks_superstaq._version.__version__"


### PR DESCRIPTION
I got (at least) one line wrong when copying+modifying the `pyproject.toml` file from `general-superstaq`.  Fixing it here.