### PR TITLE
remove failing check due to cirq bug

### DIFF
--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
@@ -774,7 +774,7 @@ def test_parallel_gates_equivalence_groups() -> None:
     ]
     for permuted_qubits in itertools.permutations(operation.qubits):
         if permuted_qubits in equivalent_targets:
-            # We don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
+            # Don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
             assert operation == gate(*permuted_qubits)
             assert cirq.equal_up_to_global_phase(operation, gate(*permuted_qubits))
         else:
@@ -803,7 +803,7 @@ def test_parallel_gates_equivalence_groups_nonadjacent() -> None:
     ]
     for permuted_qubits in itertools.permutations(operation.qubits):
         if permuted_qubits in equivalent_targets:
-            # We don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
+            # Don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
             assert operation == gate(*permuted_qubits)
             assert cirq.equal_up_to_global_phase(operation, gate(*permuted_qubits))
         else:

--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
@@ -774,8 +774,8 @@ def test_parallel_gates_equivalence_groups() -> None:
     ]
     for permuted_qubits in itertools.permutations(operation.qubits):
         if permuted_qubits in equivalent_targets:
+            # We don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
             assert operation == gate(*permuted_qubits)
-            assert cirq.approx_eq(operation, gate(*permuted_qubits))
             assert cirq.equal_up_to_global_phase(operation, gate(*permuted_qubits))
         else:
             assert operation != gate(*permuted_qubits)
@@ -803,8 +803,8 @@ def test_parallel_gates_equivalence_groups_nonadjacent() -> None:
     ]
     for permuted_qubits in itertools.permutations(operation.qubits):
         if permuted_qubits in equivalent_targets:
+            # We don't try `cirq.approx_eq` here due to https://github.com/quantumlib/Cirq/issues/6376
             assert operation == gate(*permuted_qubits)
-            assert cirq.approx_eq(operation, gate(*permuted_qubits))
             assert cirq.equal_up_to_global_phase(operation, gate(*permuted_qubits))
         else:
             assert operation != gate(*permuted_qubits)


### PR DESCRIPTION
test is failing due to https://github.com/quantumlib/Cirq/issues/6376

(this seems to have been triggered by cirq the 1.3.0 update, though tbh i'm not sure why - the comparison logic doesn't seem to have changed in a way that would have caused this)