### PR TITLE
wrap pulse schedule deserialization in try..except block

### DIFF
--- a/qiskit-superstaq/qiskit_superstaq/compiler_output.py
+++ b/qiskit-superstaq/qiskit_superstaq/compiler_output.py
@@ -218,7 +218,10 @@ def read_json(json_dict: Dict[str, str], circuits_is_list: bool) -> CompilerOutp
         pulse_gate_circuits = qss.deserialize_circuits(json_dict["pulse_gate_circuits"])
 
     if "pulses" in json_dict:
-        pulse_sequences = gss.serialization.deserialize(json_dict["pulses"])
+        try:
+            pulse_sequences = gss.serialization.deserialize(json_dict["pulses"])
+        except Exception:
+            pulse_sequences = None
 
     if circuits_is_list:
         return CompilerOutput(

--- a/qiskit-superstaq/qiskit_superstaq/compiler_output_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/compiler_output_test.py
@@ -133,6 +133,7 @@ def test_read_json() -> None:
     out = qss.compiler_output.read_json(json_dict, circuits_is_list=False)
     assert out.circuit == qc
     assert out.pulse_gate_circuit == qc_pulse
+    assert out.pulse_sequence == pulse_sequence
 
     json_dict = {
         "qiskit_circuits": qss.serialization.serialize_circuits([qc, qc]),
@@ -144,6 +145,12 @@ def test_read_json() -> None:
     out = qss.compiler_output.read_json(json_dict, circuits_is_list=True)
     assert out.circuits == [qc, qc]
     assert out.pulse_gate_circuits == [qc_pulse, qc_pulse]
+    assert out.pulse_sequences == [pulse_sequence, pulse_sequence]
+
+    json_dict["pulses"] = "oops"
+    out = qss.compiler_output.read_json(json_dict, circuits_is_list=True)
+    assert out.circuits == [qc, qc]
+    assert out.pulse_sequences is None
 
 
 @mock.patch.dict("sys.modules", {"qtrl": None})


### PR DESCRIPTION
this often fails if the user has an older version of qiskit. pulse schedules are deprecated anyway, so this shouldn't cause ibmq_compile to fail (the user should still have the corresponding pulse gate sequence)