### PR TITLE
remove duplicate `qiskit-ibm-provider` req in qss/example-requirements

### DIFF
--- a/qiskit-superstaq/example-requirements.txt
+++ b/qiskit-superstaq/example-requirements.txt
@@ -1,3 +1,2 @@
 notebook~=6.5.5
 pylatexenc
-qiskit-ibm-provider>=0.6.2


### PR DESCRIPTION
`qiskit-ibm-provider` is now part of qss's standard requirements, so doesn't need to be example-requirements too