### PR TITLE
Remove `qubovert` req in `css`

### DIFF
--- a/cirq-superstaq/requirements.txt
+++ b/cirq-superstaq/requirements.txt
@@ -1,3 +1,2 @@
 cirq>=1.0.0
 general-superstaq~=0.5.5
-qubovert>=1.2.3


### PR DESCRIPTION
Currently, `qubovert>=1.2.3` is in the `requirements.txt` of `general-superstaq`, and given that `cirq-superstaq` requires `general-superstaq`, I think the explicit requirement is not needed anymore