### PR TITLE
pin symengine 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,8 +168,8 @@ jobs:
           python-version: 3.8
       - name: Install dependencies, using minimum supported qiskit version
         run: |
-          qiskit_version=$(sed qiskit-superstaq/requirements.txt -ne 's/^qiskit.=/qiskit==/p')
-          echo "Using minimum qiskit version: $qiskit_version"
+          qiskit_version=$(sed qiskit-superstaq/requirements.txt -ne 's/^qiskit-ibm-provider.=/qiskit-ibm-provider==/p')
+          echo "Using minimum qiskit-ibm-provider version: $qiskit_version"
           python -m pip install --upgrade pip
           pip install "$qiskit_version" -e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq[dev]
       - name: Coverage check

--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -2,3 +2,4 @@ general-superstaq~=0.5.5
 matplotlib~=3.0
 qiskit>=0.44.1
 qiskit-ibm-provider>=0.7.2
+symengine~=0.11.0


### PR DESCRIPTION
symengine is required to deserialize pulse gate circuits from superstaq. qiskit only requires `>=0.9.0`, but deserialization [will fail](https://github.com/symengine/symengine/blob/bbaed4724003b882c26ef09395d87f94c1d5a451/symengine/basic.cpp#L68) if server and client aren't using the same version (up to patch)