### PR TITLE
move pydantic req to gss

### DIFF
--- a/checks-superstaq/requirements.txt
+++ b/checks-superstaq/requirements.txt
@@ -7,7 +7,6 @@ isort[colors]>=5.10.1
 mypy>=1.7.0
 nbmake>=1.3.0
 nbsphinx>=0.9.0
-pydantic>=1.10.7,<2.0.0
 pylint>=2.15.0
 pytest>=6.2.5
 pytest-cov>=2.11.1

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.21.0
+pydantic>=1.10.7,<2.0.0
 qubovert>=1.2.3
 requests>=2.26.0


### PR DESCRIPTION
(pydantic isn't required by checks-superstaq itself)