### PR TITLE
add mpl to qss example reqs

### DIFF
--- a/qiskit-superstaq/example-requirements.txt
+++ b/qiskit-superstaq/example-requirements.txt
@@ -1,3 +1,3 @@
-notebook>=6.5.5
 matplotlib>=3.0.0
+notebook>=6.5.5
 pylatexenc>=2.0

--- a/qiskit-superstaq/example-requirements.txt
+++ b/qiskit-superstaq/example-requirements.txt
@@ -1,2 +1,3 @@
 notebook>=6.5.5
+matplotlib>=3.0.0
 pylatexenc>=2.0


### PR DESCRIPTION
was removed from qss/requirements.txt in #884, but we still need it in the notebooks