### PR TITLE
Remove `pydantic` upper bound

### DIFF
--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.0
-pydantic>=1.10.7,<2.0.0
+pydantic>=1.10.7
 qubovert>=1.2.3
 requests>=2.26.0


### PR DESCRIPTION
Not needed due to https://github.com/Infleqtion/client-superstaq/pull/883

See https://github.com/Infleqtion/client-superstaq/pull/788/files#r1373726825 for more context.