### PR TITLE
Optimize critical depth computation

### DIFF
--- a/supermarq-benchmarks/supermarq/converters.py
+++ b/supermarq-benchmarks/supermarq/converters.py
@@ -145,7 +145,13 @@ def compute_depth_with_qiskit(circuit: qiskit.QuantumCircuit) -> float:
     dag = qiskit.converters.circuit_to_dag(circuit)
     dag.remove_all_ops_named("barrier")
     longest_paths = dag.count_ops_longest_path()
-    n_ed = sum([longest_paths[name] for name in {op.name for op in dag.two_qubit_ops()} if name in longest_paths])
+    n_ed = sum(
+        [
+            longest_paths[name]
+            for name in {op.name for op in dag.two_qubit_ops()}
+            if name in longest_paths
+        ]
+   )
     n_e = len(dag.two_qubit_ops())
 
     if n_ed == 0:

--- a/supermarq-benchmarks/supermarq/converters.py
+++ b/supermarq-benchmarks/supermarq/converters.py
@@ -151,7 +151,7 @@ def compute_depth_with_qiskit(circuit: qiskit.QuantumCircuit) -> float:
             for name in {op.name for op in dag.two_qubit_ops()}
             if name in longest_paths
         ]
-   )
+    )
     n_e = len(dag.two_qubit_ops())
 
     if n_ed == 0:

--- a/supermarq-benchmarks/supermarq/converters.py
+++ b/supermarq-benchmarks/supermarq/converters.py
@@ -144,13 +144,8 @@ def compute_depth_with_qiskit(circuit: qiskit.QuantumCircuit) -> float:
     """
     dag = qiskit.converters.circuit_to_dag(circuit)
     dag.remove_all_ops_named("barrier")
-    n_ed = 0
-    two_q_gates = {op.name for op in dag.two_qubit_ops()}
-    for name in two_q_gates:
-        try:
-            n_ed += dag.count_ops_longest_path()[name]
-        except KeyError:
-            continue
+    longest_paths = dag.count_ops_longest_path()
+    n_ed = sum([longest_paths[name] for name in {op.name for op in dag.two_qubit_ops()} if name in longest_paths])
     n_e = len(dag.two_qubit_ops())
 
     if n_ed == 0:


### PR DESCRIPTION
While looking through the code, I couldn't help but notice that the computation of the critical depth is unnecessarily wasteful since it would repeatedly compute `dag.count_ops_longest_path()`.
Furthermore, this PR uses a arguably more Pythonic and concise way of computing `n_ed`.