### PR TITLE
fix barrier symbol in transposed diagrams

### DIFF
--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
@@ -406,8 +406,11 @@ class Barrier(cirq.ops.IdentityGate, cirq.InterchangeableQubitsGate):
 
     def _circuit_diagram_info_(self, args: cirq.CircuitDiagramInfoArgs) -> tuple[str, ...]:
         if args.use_unicode_characters:
-            return ("│",) * self.num_qubits()
-        return ("|",) * self.num_qubits()
+            wire_symbol = "─" if args.transpose else "│"
+        else:
+            wire_symbol = "-" if args.transpose else "|"
+
+        return (wire_symbol,) * self.num_qubits()
 
 
 def barrier(*qubits: cirq.Qid) -> cirq.Operation:

--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
@@ -571,6 +571,34 @@ def test_barrier() -> None:
         use_unicode_characters=False,
     )
 
+    cirq.testing.assert_has_diagram(
+        circuit,
+        textwrap.dedent(
+            """
+            0 1 2
+            │ │ │
+            ─────
+            │ │ │
+            """
+        ),
+        use_unicode_characters=True,
+        transpose=True,
+    )
+
+    cirq.testing.assert_has_diagram(
+        circuit,
+        textwrap.dedent(
+            """
+            0 1 2
+            | | |
+            -----
+            | | |
+            """
+        ),
+        use_unicode_characters=False,
+        transpose=True,
+    )
+
     # make sure optimizations don't drop Barriers:
     circuit = cirq.drop_negligible_operations(circuit)
     assert circuit == cirq.Circuit(operation)


### PR DESCRIPTION
currently we don't rotate the vertical bars over the qubit wires for transposed diagrams, so they don't really look much like barriers:
```
0 1 2 3
│ │ │ │
H X─┼─@
│ │ │ │
│─│─│ │
│ │ │ │
```
after this pr they're much more apparent (and consistent with the horizontal diagram):
```
0 1 2 3
│ │ │ │
H X─┼─@
│ │ │ │
───── │
│ │ │ │
```
