### PR TITLE
Remove qubovert requirement

### DIFF
--- a/docs/source/apps/max_sharpe_ratio_optimization.ipynb
+++ b/docs/source/apps/max_sharpe_ratio_optimization.ipynb
@@ -57,7 +57,16 @@
     "    %pip install --quiet yfinance\n",
     "    print(\"Installed yfinance.\")\n",
     "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
-    "    import yfinance as yf"
+    "    import yfinance as yf\n",
+    "\n",
+    "try:\n",
+    "    import qubovert as qv\n",
+    "except ImportError:\n",
+    "    print(\"Installing qubovert...\")\n",
+    "    %pip install --quiet qubovert\n",
+    "    print(\"Installed qubovert.\")\n",
+    "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
+    "    import qubovert as qv"
    ]
   },
   {
@@ -74,7 +83,6 @@
     "import pandas as pd\n",
     "import sympy\n",
     "from tqdm import tqdm\n",
-    "import qubovert as qv\n",
     "\n",
     "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)"
    ]

--- a/general-superstaq/general_superstaq/service.py
+++ b/general-superstaq/general_superstaq/service.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import numbers
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
-
-import qubovert as qv
 
 import general_superstaq as gss
 
@@ -161,7 +159,7 @@ class Service:
 
     def submit_qubo(
         self,
-        qubo: qv.QUBO,
+        qubo: Mapping[tuple[int, ...], int | float],
         target: str,
         repetitions: int = 1000,
         method: str | None = None,
@@ -173,7 +171,7 @@ class Service:
         the energy landscape from the given objective function known as output solutions.
 
         Args:
-            qubo: A `qv.QUBO` object.
+            qubo: A dictionary representing the QUBO object.
             target: The target to submit the qubo.
             repetitions: Number of times that the execution is repeated before stopping.
             method: The parameter specifying method of QUBO solving execution. Currently,

--- a/general-superstaq/general_superstaq/service_test.py
+++ b/general-superstaq/general_superstaq/service_test.py
@@ -5,7 +5,6 @@ import tempfile
 from unittest import mock
 
 import pytest
-import qubovert as qv
 
 import general_superstaq as gss
 from general_superstaq.testing import RETURNED_TARGETS, TARGET_LIST
@@ -91,7 +90,7 @@ def test_update_user_role(
 def test_submit_qubo(
     mock_post_request: mock.MagicMock,
 ) -> None:
-    example_qubo = qv.QUBO({(0,): 1.0, (1,): 1.0, (0, 1): -2.0})
+    example_qubo = {(0,): 1.0, (1,): 1.0, (0, 1): -2.0}
     target = "toshiba_bifurcation_simulator"
     repetitions = 10
 

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -24,7 +24,6 @@ import warnings
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
-import qubovert as qv
 import requests
 
 import general_superstaq as gss
@@ -336,7 +335,7 @@ class _SuperstaqClient:
 
     def submit_qubo(
         self,
-        qubo: qv.QUBO,
+        qubo: Mapping[tuple[int, ...], int | float],
         target: str,
         repetitions: int = 1000,
         method: str | None = None,
@@ -346,7 +345,7 @@ class _SuperstaqClient:
         given target.
 
         Args:
-            qubo: A `qv.QUBO` object.
+            qubo: A dictionary representing the QUBO object.
             target: The target to submit the qubo.
             repetitions: Number of times that the execution is repeated before stopping.
             method: The parameter specifying method of QUBO solving execution. Currently,

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -18,7 +18,6 @@ import os
 from unittest import mock
 
 import pytest
-import qubovert as qv
 import requests
 
 import general_superstaq as gss
@@ -645,7 +644,7 @@ def test_superstaq_client_submit_qubo(mock_post: mock.MagicMock) -> None:
         api_key="to_my_heart",
     )
 
-    example_qubo = qv.QUBO({(0,): 1.0, (1,): 1.0, (0, 1): -2.0})
+    example_qubo = {(0,): 1.0, (1,): 1.0, (0, 1): -2.0}
     target = "toshiba_bifurcation_simulator"
     repetitions = 10
     client.submit_qubo(

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.21.0
 pydantic>=1.10.7
-qubovert>=1.2.3
 requests>=2.26.0


### PR DESCRIPTION
Removes the qubovert requirement in `gss` as it was primarily used for typing purposes. It should be an optional install for users like in the MIS notebook. 