### PR TITLE
Add `supports_submit_qubo` filter to `backends()`

### DIFF
--- a/docs/source/get_started/access_info/access_info_qss.ipynb
+++ b/docs/source/get_started/access_info/access_info_qss.ipynb
@@ -110,7 +110,7 @@
     "## Backend Information\n",
     "In addition to account information, the ``SuperstaqProvider`` object also gives you a list of all the devices and simulators to which you have access, as well as additional information about those backends.\n",
     "\n",
-    "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the backends returned: `simulator`, `supports_submit`, `supports_compile`, `available`, and `retired`.\n",
+    "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the backends returned: `simulator`, `supports_submit`, `supports_submit_qubo`, `supports_compile`, `available`, and `retired`.\n",
     "* `backends()`: Retrieves a list of available backends. This method also accepts the same keyword arguments as mentioned above.\n",
     "* `get_backend(\"<backend_name>\")`: Select your target backend, where `<backend_name>` is the name of the desired backend\n",
     "* `get_backend(\"<backend_name>\").target_info()`: Retrieve information on your selected backend, such as number of qubits, native gate set"

--- a/docs/source/get_started/access_info/access_info_qss.ipynb
+++ b/docs/source/get_started/access_info/access_info_qss.ipynb
@@ -1,697 +1,697 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "cf056b55",
-            "metadata": {},
-            "source": [
-                "# Accessing info with `qiskit-superstaq`\n",
-                "This tutorial will cover the information you can access on your account and related jobs and backends using `qiskit-superstaq`."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "70537a94",
-            "metadata": {},
-            "source": [
-                "## Imports and API Token\n",
-                "\n",
-                "As usual, we'll begin with importing requirements and setting up access to Superstaq. This tutorial uses `qiskit-superstaq`, our Superstaq client for Qiskit. You can install it and relevant dependencies by running `pip install qiskit-superstaq[examples]`."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "id": "1a637717",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Requirements to use qiskit-superstaq\n",
-                "try:\n",
-                "    import qiskit\n",
-                "    import qiskit_superstaq as qss\n",
-                "except ImportError:\n",
-                "    print(\"Installing qiskit-superstaq...\")\n",
-                "    %pip install --quiet 'qiskit-superstaq[examples]'\n",
-                "    print(\"Installed qiskit-superstaq.\")\n",
-                "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
-                "    import qiskit\n",
-                "    import qiskit_superstaq as qss"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "55ead78f",
-            "metadata": {},
-            "source": [
-                "Now, we instantiate a provider in `qiskit-superstaq` with `SuperstaqProvider()`. Supply the Superstaq API token by providing the token as an argument of `qss.SuperstaqProvider()` or setting it as an environment variable (see [this guide](https://superstaq.readthedocs.io/en/latest/get_started/basics/basics_qss.html#Set-up-access-to-Superstaq%E2%80%99s-API))."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "562b5d46",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "provider = qss.SuperstaqProvider()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "42932197",
-            "metadata": {},
-            "source": [
-                "## Account Information"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "10fc81e6",
-            "metadata": {},
-            "source": [
-                "The `provider` class gives you a means to retrieve information regarding your Superstaq account. Currently, you can use `provider` to retrieve your Superstaq balance."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 3,
-            "id": "f0730b90",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "'20 credits'"
-                        ]
-                    },
-                    "execution_count": 3,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "provider.get_balance()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "91a268ec",
-            "metadata": {},
-            "source": [
-                "If are interested in increasing your balance or have more information on your user role, please reach out to us at superstaq@infleqtion.com or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "332617c4",
-            "metadata": {},
-            "source": [
-                "## Backend Information\n",
-                "In addition to account information, the ``SuperstaqProvider`` object also gives you a list of all the devices and simulators to which you have access, as well as additional information about those backends.\n",
-                "\n",
-                "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the targets returned: `simulator`, `supports_submit`, `supports_submit_qubo`, `supports_compile`, `available`, and `retired`.\n",
-                "* `backends()`: Retrieves a list of available backends. This method also accepts the same keyword arguments as mentioned above.\n",
-                "* `get_backend(\"<backend_name>\")`: Select your target backend, where `<backend_name>` is the name of the desired backend\n",
-                "* `get_backend(\"<backend_name>\").target_info()`: Retrieve information on your selected backend, such as number of qubits, native gate set"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 4,
-            "id": "7ab7e0ff",
-            "metadata": {
-                "scrolled": false
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "[Target(target='aqt_keysight_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='aqt_zurich_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='aws_dm1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='aws_sv1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='aws_tn1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='cq_hilbert_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='cq_hilbert_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_brisbane_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_extended-stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_kyoto_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_mps_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_osaka_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_qasm_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ibmq_statevector_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ionq_aria-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-                            " Target(target='ionq_aria-2_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-                            " Target(target='ionq_forte-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-                            " Target(target='ionq_harmony_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ionq_ion_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='oxford_lucy_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-                            " Target(target='qtm_h1-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='qtm_h1-1e_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='qtm_h2-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='rigetti_aspen-m-3_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-                            " Target(target='qscout_peregrine_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-                            " Target(target='ss_unconstrained_simulator', supports_submit=True, supports_submit_qubo=True, supports_compile=True, available=True, retired=False)]"
-                        ]
-                    },
-                    "execution_count": 4,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "provider.get_targets()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 5,
-            "id": "58ce4b24",
-            "metadata": {
-                "scrolled": true
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "{'backend_name': 'ibmq_brisbane_qpu',\n",
-                            " 'backend_version': 'n/a',\n",
-                            " 'n_qubits': 127,\n",
-                            " 'basis_gates': ['ecr', 'id', 'rz', 'sx', 'x'],\n",
-                            " 'gates': [],\n",
-                            " 'local': False,\n",
-                            " 'simulator': False,\n",
-                            " 'conditional': False,\n",
-                            " 'open_pulse': True,\n",
-                            " 'memory': False,\n",
-                            " 'max_shots': 100000,\n",
-                            " 'coupling_map': [[0, 1],\n",
-                            "  [0, 14],\n",
-                            "  [1, 0],\n",
-                            "  [1, 2],\n",
-                            "  [2, 1],\n",
-                            "  [2, 3],\n",
-                            "  [3, 2],\n",
-                            "  [3, 4],\n",
-                            "  [4, 3],\n",
-                            "  [4, 5],\n",
-                            "  [4, 15],\n",
-                            "  [5, 4],\n",
-                            "  [5, 6],\n",
-                            "  [6, 5],\n",
-                            "  [6, 7],\n",
-                            "  [7, 6],\n",
-                            "  [7, 8],\n",
-                            "  [8, 7],\n",
-                            "  [8, 9],\n",
-                            "  [8, 16],\n",
-                            "  [9, 8],\n",
-                            "  [9, 10],\n",
-                            "  [10, 9],\n",
-                            "  [10, 11],\n",
-                            "  [11, 10],\n",
-                            "  [11, 12],\n",
-                            "  [12, 11],\n",
-                            "  [12, 13],\n",
-                            "  [12, 17],\n",
-                            "  [13, 12],\n",
-                            "  [14, 0],\n",
-                            "  [14, 18],\n",
-                            "  [15, 4],\n",
-                            "  [15, 22],\n",
-                            "  [16, 8],\n",
-                            "  [16, 26],\n",
-                            "  [17, 12],\n",
-                            "  [17, 30],\n",
-                            "  [18, 14],\n",
-                            "  [18, 19],\n",
-                            "  [19, 18],\n",
-                            "  [19, 20],\n",
-                            "  [20, 19],\n",
-                            "  [20, 21],\n",
-                            "  [20, 33],\n",
-                            "  [21, 20],\n",
-                            "  [21, 22],\n",
-                            "  [22, 15],\n",
-                            "  [22, 21],\n",
-                            "  [22, 23],\n",
-                            "  [23, 22],\n",
-                            "  [23, 24],\n",
-                            "  [24, 23],\n",
-                            "  [24, 25],\n",
-                            "  [24, 34],\n",
-                            "  [25, 24],\n",
-                            "  [25, 26],\n",
-                            "  [26, 16],\n",
-                            "  [26, 25],\n",
-                            "  [26, 27],\n",
-                            "  [27, 26],\n",
-                            "  [27, 28],\n",
-                            "  [28, 27],\n",
-                            "  [28, 29],\n",
-                            "  [28, 35],\n",
-                            "  [29, 28],\n",
-                            "  [29, 30],\n",
-                            "  [30, 17],\n",
-                            "  [30, 29],\n",
-                            "  [30, 31],\n",
-                            "  [31, 30],\n",
-                            "  [31, 32],\n",
-                            "  [32, 31],\n",
-                            "  [32, 36],\n",
-                            "  [33, 20],\n",
-                            "  [33, 39],\n",
-                            "  [34, 24],\n",
-                            "  [34, 43],\n",
-                            "  [35, 28],\n",
-                            "  [35, 47],\n",
-                            "  [36, 32],\n",
-                            "  [36, 51],\n",
-                            "  [37, 38],\n",
-                            "  [37, 52],\n",
-                            "  [38, 37],\n",
-                            "  [38, 39],\n",
-                            "  [39, 33],\n",
-                            "  [39, 38],\n",
-                            "  [39, 40],\n",
-                            "  [40, 39],\n",
-                            "  [40, 41],\n",
-                            "  [41, 40],\n",
-                            "  [41, 42],\n",
-                            "  [41, 53],\n",
-                            "  [42, 41],\n",
-                            "  [42, 43],\n",
-                            "  [43, 34],\n",
-                            "  [43, 42],\n",
-                            "  [43, 44],\n",
-                            "  [44, 43],\n",
-                            "  [44, 45],\n",
-                            "  [45, 44],\n",
-                            "  [45, 46],\n",
-                            "  [45, 54],\n",
-                            "  [46, 45],\n",
-                            "  [46, 47],\n",
-                            "  [47, 35],\n",
-                            "  [47, 46],\n",
-                            "  [47, 48],\n",
-                            "  [48, 47],\n",
-                            "  [48, 49],\n",
-                            "  [49, 48],\n",
-                            "  [49, 50],\n",
-                            "  [49, 55],\n",
-                            "  [50, 49],\n",
-                            "  [50, 51],\n",
-                            "  [51, 36],\n",
-                            "  [51, 50],\n",
-                            "  [52, 37],\n",
-                            "  [52, 56],\n",
-                            "  [53, 41],\n",
-                            "  [53, 60],\n",
-                            "  [54, 45],\n",
-                            "  [54, 64],\n",
-                            "  [55, 49],\n",
-                            "  [55, 68],\n",
-                            "  [56, 52],\n",
-                            "  [56, 57],\n",
-                            "  [57, 56],\n",
-                            "  [57, 58],\n",
-                            "  [58, 57],\n",
-                            "  [58, 59],\n",
-                            "  [58, 71],\n",
-                            "  [59, 58],\n",
-                            "  [59, 60],\n",
-                            "  [60, 53],\n",
-                            "  [60, 59],\n",
-                            "  [60, 61],\n",
-                            "  [61, 60],\n",
-                            "  [61, 62],\n",
-                            "  [62, 61],\n",
-                            "  [62, 63],\n",
-                            "  [62, 72],\n",
-                            "  [63, 62],\n",
-                            "  [63, 64],\n",
-                            "  [64, 54],\n",
-                            "  [64, 63],\n",
-                            "  [64, 65],\n",
-                            "  [65, 64],\n",
-                            "  [65, 66],\n",
-                            "  [66, 65],\n",
-                            "  [66, 67],\n",
-                            "  [66, 73],\n",
-                            "  [67, 66],\n",
-                            "  [67, 68],\n",
-                            "  [68, 55],\n",
-                            "  [68, 67],\n",
-                            "  [68, 69],\n",
-                            "  [69, 68],\n",
-                            "  [69, 70],\n",
-                            "  [70, 69],\n",
-                            "  [70, 74],\n",
-                            "  [71, 58],\n",
-                            "  [71, 77],\n",
-                            "  [72, 62],\n",
-                            "  [72, 81],\n",
-                            "  [73, 66],\n",
-                            "  [73, 85],\n",
-                            "  [74, 70],\n",
-                            "  [74, 89],\n",
-                            "  [75, 76],\n",
-                            "  [75, 90],\n",
-                            "  [76, 75],\n",
-                            "  [76, 77],\n",
-                            "  [77, 71],\n",
-                            "  [77, 76],\n",
-                            "  [77, 78],\n",
-                            "  [78, 77],\n",
-                            "  [78, 79],\n",
-                            "  [79, 78],\n",
-                            "  [79, 80],\n",
-                            "  [79, 91],\n",
-                            "  [80, 79],\n",
-                            "  [80, 81],\n",
-                            "  [81, 72],\n",
-                            "  [81, 80],\n",
-                            "  [81, 82],\n",
-                            "  [82, 81],\n",
-                            "  [82, 83],\n",
-                            "  [83, 82],\n",
-                            "  [83, 84],\n",
-                            "  [83, 92],\n",
-                            "  [84, 83],\n",
-                            "  [84, 85],\n",
-                            "  [85, 73],\n",
-                            "  [85, 84],\n",
-                            "  [85, 86],\n",
-                            "  [86, 85],\n",
-                            "  [86, 87],\n",
-                            "  [87, 86],\n",
-                            "  [87, 88],\n",
-                            "  [87, 93],\n",
-                            "  [88, 87],\n",
-                            "  [88, 89],\n",
-                            "  [89, 74],\n",
-                            "  [89, 88],\n",
-                            "  [90, 75],\n",
-                            "  [90, 94],\n",
-                            "  [91, 79],\n",
-                            "  [91, 98],\n",
-                            "  [92, 83],\n",
-                            "  [92, 102],\n",
-                            "  [93, 87],\n",
-                            "  [93, 106],\n",
-                            "  [94, 90],\n",
-                            "  [94, 95],\n",
-                            "  [95, 94],\n",
-                            "  [95, 96],\n",
-                            "  [96, 95],\n",
-                            "  [96, 97],\n",
-                            "  [96, 109],\n",
-                            "  [97, 96],\n",
-                            "  [97, 98],\n",
-                            "  [98, 91],\n",
-                            "  [98, 97],\n",
-                            "  [98, 99],\n",
-                            "  [99, 98],\n",
-                            "  [99, 100],\n",
-                            "  [100, 99],\n",
-                            "  [100, 101],\n",
-                            "  [100, 110],\n",
-                            "  [101, 100],\n",
-                            "  [101, 102],\n",
-                            "  [102, 92],\n",
-                            "  [102, 101],\n",
-                            "  [102, 103],\n",
-                            "  [103, 102],\n",
-                            "  [103, 104],\n",
-                            "  [104, 103],\n",
-                            "  [104, 105],\n",
-                            "  [104, 111],\n",
-                            "  [105, 104],\n",
-                            "  [105, 106],\n",
-                            "  [106, 93],\n",
-                            "  [106, 105],\n",
-                            "  [106, 107],\n",
-                            "  [107, 106],\n",
-                            "  [107, 108],\n",
-                            "  [108, 107],\n",
-                            "  [108, 112],\n",
-                            "  [109, 96],\n",
-                            "  [109, 114],\n",
-                            "  [110, 100],\n",
-                            "  [110, 118],\n",
-                            "  [111, 104],\n",
-                            "  [111, 122],\n",
-                            "  [112, 108],\n",
-                            "  [112, 126],\n",
-                            "  [113, 114],\n",
-                            "  [114, 109],\n",
-                            "  [114, 113],\n",
-                            "  [114, 115],\n",
-                            "  [115, 114],\n",
-                            "  [115, 116],\n",
-                            "  [116, 115],\n",
-                            "  [116, 117],\n",
-                            "  [117, 116],\n",
-                            "  [117, 118],\n",
-                            "  [118, 110],\n",
-                            "  [118, 117],\n",
-                            "  [118, 119],\n",
-                            "  [119, 118],\n",
-                            "  [119, 120],\n",
-                            "  [120, 119],\n",
-                            "  [120, 121],\n",
-                            "  [121, 120],\n",
-                            "  [121, 122],\n",
-                            "  [122, 111],\n",
-                            "  [122, 121],\n",
-                            "  [122, 123],\n",
-                            "  [123, 122],\n",
-                            "  [123, 124],\n",
-                            "  [124, 123],\n",
-                            "  [124, 125],\n",
-                            "  [125, 124],\n",
-                            "  [125, 126],\n",
-                            "  [126, 112],\n",
-                            "  [126, 125]],\n",
-                            " 'description': '127 qubit device',\n",
-                            " 'supports_midcircuit_measurement': True,\n",
-                            " 'max_experiments': 300,\n",
-                            " 'processor_type': {'family': 'Eagle', 'revision': 3}}"
-                        ]
-                    },
-                    "execution_count": 5,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "backend = provider.get_backend(\"ibmq_brisbane_qpu\")  # selecting the IBM Brisbane device\n",
-                "backend.target_info()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "541a58fe",
-            "metadata": {},
-            "source": [
-                "## Job Information\n",
-                "Jobs submitted through Superstaq contain the following information:\n",
-                "\n",
-                "* `job_id()`: Unique identifier for the job.\n",
-                "* `status()`: Status of the job (either Queued, Running, Done).\n",
-                "* `backend()`: Device the job was run on.\n",
-                "* `result().get_counts()`: Counts from the result of the job run. Note that `result()` can take an `index` argument to retrieve a specific job result (corresponding to the circuit with the same `index`). It also optionally accepts a list of qubit indices to retrieve marginal counts on specific qubits via the `qubit_indices` argument of `result()`.\n",
-                "* `input_circuits()`: Retrieves original (i.e., not compiled) circuit(s) for job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
-                "* `compiled_circuits()`: Retrieves compiled circuit(s) from submitted job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
-                "\n",
-                "Note that jobs live in our database for a limited amount of time. Typically, they have a lifespan of 1 year."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 6,
-            "id": "dbd6a92a",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# Creating a circuit using Qiskit\n",
-                "qc = qiskit.QuantumCircuit(2, 2)\n",
-                "qc.h(0)\n",
-                "qc.cx(0, 1)\n",
-                "qc.measure([0, 1], [0, 1])\n",
-                "\n",
-                "# Submitting the circuit to the IBM Q QASM Simulator\n",
-                "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-                "job = backend.run(\n",
-                "    [qc], method=\"dry-run\", shots=100\n",
-                ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 7,
-            "id": "a4e0461c",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "'50a836d2-3a2e-4cbb-8bae-5f9108b547f3'"
-                        ]
-                    },
-                    "execution_count": 7,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "job.job_id()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 8,
-            "id": "95d79658",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "<JobStatus.DONE: 'job has successfully run'>"
-                        ]
-                    },
-                    "execution_count": 8,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "job.status()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 9,
-            "id": "878046e1",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "<SuperstaqBackend('ibmq_qasm_simulator')>"
-                        ]
-                    },
-                    "execution_count": 9,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "job.backend()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 10,
-            "id": "f8e4e681",
-            "metadata": {
-                "scrolled": true
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "text/plain": [
-                            "{'00': 48, '11': 52}"
-                        ]
-                    },
-                    "execution_count": 10,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "job.result(index=0).get_counts()"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 11,
-            "id": "6adf4b5b",
-            "metadata": {
-                "scrolled": true
-            },
-            "outputs": [
-                {
-                    "data": {
-                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
-                        "text/plain": [
-                            "<Figure size 454.517x284.278 with 1 Axes>"
-                        ]
-                    },
-                    "execution_count": 11,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "job.input_circuits(index=0).draw(output=\"mpl\")"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "c47082b8",
-            "metadata": {},
-            "source": [
-                "You may also retrieve the information described above on a previously submitted `qiskit-superstaq` job:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 12,
-            "id": "16bdcfff",
-            "metadata": {},
-            "outputs": [
-                {
-                    "data": {
-                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
-                        "text/plain": [
-                            "<Figure size 454.517x284.278 with 1 Axes>"
-                        ]
-                    },
-                    "execution_count": 12,
-                    "metadata": {},
-                    "output_type": "execute_result"
-                }
-            ],
-            "source": [
-                "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-                "job_id = job.job_id()  # Here we use the job ID from above, but this can be any old job ID\n",
-                "job_old = backend.retrieve_job(job_id)\n",
-                "job_old.input_circuits(index=0).draw(output=\"mpl\")"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3 (ipykernel)",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.9.16"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cf056b55",
+   "metadata": {},
+   "source": [
+    "# Accessing info with `qiskit-superstaq`\n",
+    "This tutorial will cover the information you can access on your account and related jobs and backends using `qiskit-superstaq`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70537a94",
+   "metadata": {},
+   "source": [
+    "## Imports and API Token\n",
+    "\n",
+    "As usual, we'll begin with importing requirements and setting up access to Superstaq. This tutorial uses `qiskit-superstaq`, our Superstaq client for Qiskit. You can install it and relevant dependencies by running `pip install qiskit-superstaq[examples]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1a637717",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Requirements to use qiskit-superstaq\n",
+    "try:\n",
+    "    import qiskit\n",
+    "    import qiskit_superstaq as qss\n",
+    "except ImportError:\n",
+    "    print(\"Installing qiskit-superstaq...\")\n",
+    "    %pip install --quiet 'qiskit-superstaq[examples]'\n",
+    "    print(\"Installed qiskit-superstaq.\")\n",
+    "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
+    "    import qiskit\n",
+    "    import qiskit_superstaq as qss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55ead78f",
+   "metadata": {},
+   "source": [
+    "Now, we instantiate a provider in `qiskit-superstaq` with `SuperstaqProvider()`. Supply the Superstaq API token by providing the token as an argument of `qss.SuperstaqProvider()` or setting it as an environment variable (see [this guide](https://superstaq.readthedocs.io/en/latest/get_started/basics/basics_qss.html#Set-up-access-to-Superstaq%E2%80%99s-API))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "562b5d46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider = qss.SuperstaqProvider()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42932197",
+   "metadata": {},
+   "source": [
+    "## Account Information"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10fc81e6",
+   "metadata": {},
+   "source": [
+    "The `provider` class gives you a means to retrieve information regarding your Superstaq account. Currently, you can use `provider` to retrieve your Superstaq balance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f0730b90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'20 credits'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "provider.get_balance()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91a268ec",
+   "metadata": {},
+   "source": [
+    "If are interested in increasing your balance or have more information on your user role, please reach out to us at superstaq@infleqtion.com or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "332617c4",
+   "metadata": {},
+   "source": [
+    "## Backend Information\n",
+    "In addition to account information, the ``SuperstaqProvider`` object also gives you a list of all the devices and simulators to which you have access, as well as additional information about those backends.\n",
+    "\n",
+    "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the backends returned: `simulator`, `supports_submit`, `supports_compile`, `available`, and `retired`.\n",
+    "* `backends()`: Retrieves a list of available backends. This method also accepts the same keyword arguments as mentioned above.\n",
+    "* `get_backend(\"<backend_name>\")`: Select your target backend, where `<backend_name>` is the name of the desired backend\n",
+    "* `get_backend(\"<backend_name>\").target_info()`: Retrieve information on your selected backend, such as number of qubits, native gate set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7ab7e0ff",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+        "[Target(target='aqt_keysight_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='aqt_zurich_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='aws_dm1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='aws_sv1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='aws_tn1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='cq_hilbert_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='cq_hilbert_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_brisbane_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_extended-stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_kyoto_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_mps_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_osaka_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_qasm_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ibmq_statevector_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ionq_aria-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+        " Target(target='ionq_aria-2_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+        " Target(target='ionq_forte-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+        " Target(target='ionq_harmony_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ionq_ion_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='oxford_lucy_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+        " Target(target='qtm_h1-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='qtm_h1-1e_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='qtm_h2-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='rigetti_aspen-m-3_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+        " Target(target='qscout_peregrine_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+        " Target(target='ss_unconstrained_simulator', supports_submit=True, supports_submit_qubo=True, supports_compile=True, available=True, retired=False)]"
+       ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "provider.get_targets()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "58ce4b24",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'backend_name': 'ibmq_brisbane_qpu',\n",
+       " 'backend_version': 'n/a',\n",
+       " 'n_qubits': 127,\n",
+       " 'basis_gates': ['ecr', 'id', 'rz', 'sx', 'x'],\n",
+       " 'gates': [],\n",
+       " 'local': False,\n",
+       " 'simulator': False,\n",
+       " 'conditional': False,\n",
+       " 'open_pulse': True,\n",
+       " 'memory': False,\n",
+       " 'max_shots': 100000,\n",
+       " 'coupling_map': [[0, 1],\n",
+       "  [0, 14],\n",
+       "  [1, 0],\n",
+       "  [1, 2],\n",
+       "  [2, 1],\n",
+       "  [2, 3],\n",
+       "  [3, 2],\n",
+       "  [3, 4],\n",
+       "  [4, 3],\n",
+       "  [4, 5],\n",
+       "  [4, 15],\n",
+       "  [5, 4],\n",
+       "  [5, 6],\n",
+       "  [6, 5],\n",
+       "  [6, 7],\n",
+       "  [7, 6],\n",
+       "  [7, 8],\n",
+       "  [8, 7],\n",
+       "  [8, 9],\n",
+       "  [8, 16],\n",
+       "  [9, 8],\n",
+       "  [9, 10],\n",
+       "  [10, 9],\n",
+       "  [10, 11],\n",
+       "  [11, 10],\n",
+       "  [11, 12],\n",
+       "  [12, 11],\n",
+       "  [12, 13],\n",
+       "  [12, 17],\n",
+       "  [13, 12],\n",
+       "  [14, 0],\n",
+       "  [14, 18],\n",
+       "  [15, 4],\n",
+       "  [15, 22],\n",
+       "  [16, 8],\n",
+       "  [16, 26],\n",
+       "  [17, 12],\n",
+       "  [17, 30],\n",
+       "  [18, 14],\n",
+       "  [18, 19],\n",
+       "  [19, 18],\n",
+       "  [19, 20],\n",
+       "  [20, 19],\n",
+       "  [20, 21],\n",
+       "  [20, 33],\n",
+       "  [21, 20],\n",
+       "  [21, 22],\n",
+       "  [22, 15],\n",
+       "  [22, 21],\n",
+       "  [22, 23],\n",
+       "  [23, 22],\n",
+       "  [23, 24],\n",
+       "  [24, 23],\n",
+       "  [24, 25],\n",
+       "  [24, 34],\n",
+       "  [25, 24],\n",
+       "  [25, 26],\n",
+       "  [26, 16],\n",
+       "  [26, 25],\n",
+       "  [26, 27],\n",
+       "  [27, 26],\n",
+       "  [27, 28],\n",
+       "  [28, 27],\n",
+       "  [28, 29],\n",
+       "  [28, 35],\n",
+       "  [29, 28],\n",
+       "  [29, 30],\n",
+       "  [30, 17],\n",
+       "  [30, 29],\n",
+       "  [30, 31],\n",
+       "  [31, 30],\n",
+       "  [31, 32],\n",
+       "  [32, 31],\n",
+       "  [32, 36],\n",
+       "  [33, 20],\n",
+       "  [33, 39],\n",
+       "  [34, 24],\n",
+       "  [34, 43],\n",
+       "  [35, 28],\n",
+       "  [35, 47],\n",
+       "  [36, 32],\n",
+       "  [36, 51],\n",
+       "  [37, 38],\n",
+       "  [37, 52],\n",
+       "  [38, 37],\n",
+       "  [38, 39],\n",
+       "  [39, 33],\n",
+       "  [39, 38],\n",
+       "  [39, 40],\n",
+       "  [40, 39],\n",
+       "  [40, 41],\n",
+       "  [41, 40],\n",
+       "  [41, 42],\n",
+       "  [41, 53],\n",
+       "  [42, 41],\n",
+       "  [42, 43],\n",
+       "  [43, 34],\n",
+       "  [43, 42],\n",
+       "  [43, 44],\n",
+       "  [44, 43],\n",
+       "  [44, 45],\n",
+       "  [45, 44],\n",
+       "  [45, 46],\n",
+       "  [45, 54],\n",
+       "  [46, 45],\n",
+       "  [46, 47],\n",
+       "  [47, 35],\n",
+       "  [47, 46],\n",
+       "  [47, 48],\n",
+       "  [48, 47],\n",
+       "  [48, 49],\n",
+       "  [49, 48],\n",
+       "  [49, 50],\n",
+       "  [49, 55],\n",
+       "  [50, 49],\n",
+       "  [50, 51],\n",
+       "  [51, 36],\n",
+       "  [51, 50],\n",
+       "  [52, 37],\n",
+       "  [52, 56],\n",
+       "  [53, 41],\n",
+       "  [53, 60],\n",
+       "  [54, 45],\n",
+       "  [54, 64],\n",
+       "  [55, 49],\n",
+       "  [55, 68],\n",
+       "  [56, 52],\n",
+       "  [56, 57],\n",
+       "  [57, 56],\n",
+       "  [57, 58],\n",
+       "  [58, 57],\n",
+       "  [58, 59],\n",
+       "  [58, 71],\n",
+       "  [59, 58],\n",
+       "  [59, 60],\n",
+       "  [60, 53],\n",
+       "  [60, 59],\n",
+       "  [60, 61],\n",
+       "  [61, 60],\n",
+       "  [61, 62],\n",
+       "  [62, 61],\n",
+       "  [62, 63],\n",
+       "  [62, 72],\n",
+       "  [63, 62],\n",
+       "  [63, 64],\n",
+       "  [64, 54],\n",
+       "  [64, 63],\n",
+       "  [64, 65],\n",
+       "  [65, 64],\n",
+       "  [65, 66],\n",
+       "  [66, 65],\n",
+       "  [66, 67],\n",
+       "  [66, 73],\n",
+       "  [67, 66],\n",
+       "  [67, 68],\n",
+       "  [68, 55],\n",
+       "  [68, 67],\n",
+       "  [68, 69],\n",
+       "  [69, 68],\n",
+       "  [69, 70],\n",
+       "  [70, 69],\n",
+       "  [70, 74],\n",
+       "  [71, 58],\n",
+       "  [71, 77],\n",
+       "  [72, 62],\n",
+       "  [72, 81],\n",
+       "  [73, 66],\n",
+       "  [73, 85],\n",
+       "  [74, 70],\n",
+       "  [74, 89],\n",
+       "  [75, 76],\n",
+       "  [75, 90],\n",
+       "  [76, 75],\n",
+       "  [76, 77],\n",
+       "  [77, 71],\n",
+       "  [77, 76],\n",
+       "  [77, 78],\n",
+       "  [78, 77],\n",
+       "  [78, 79],\n",
+       "  [79, 78],\n",
+       "  [79, 80],\n",
+       "  [79, 91],\n",
+       "  [80, 79],\n",
+       "  [80, 81],\n",
+       "  [81, 72],\n",
+       "  [81, 80],\n",
+       "  [81, 82],\n",
+       "  [82, 81],\n",
+       "  [82, 83],\n",
+       "  [83, 82],\n",
+       "  [83, 84],\n",
+       "  [83, 92],\n",
+       "  [84, 83],\n",
+       "  [84, 85],\n",
+       "  [85, 73],\n",
+       "  [85, 84],\n",
+       "  [85, 86],\n",
+       "  [86, 85],\n",
+       "  [86, 87],\n",
+       "  [87, 86],\n",
+       "  [87, 88],\n",
+       "  [87, 93],\n",
+       "  [88, 87],\n",
+       "  [88, 89],\n",
+       "  [89, 74],\n",
+       "  [89, 88],\n",
+       "  [90, 75],\n",
+       "  [90, 94],\n",
+       "  [91, 79],\n",
+       "  [91, 98],\n",
+       "  [92, 83],\n",
+       "  [92, 102],\n",
+       "  [93, 87],\n",
+       "  [93, 106],\n",
+       "  [94, 90],\n",
+       "  [94, 95],\n",
+       "  [95, 94],\n",
+       "  [95, 96],\n",
+       "  [96, 95],\n",
+       "  [96, 97],\n",
+       "  [96, 109],\n",
+       "  [97, 96],\n",
+       "  [97, 98],\n",
+       "  [98, 91],\n",
+       "  [98, 97],\n",
+       "  [98, 99],\n",
+       "  [99, 98],\n",
+       "  [99, 100],\n",
+       "  [100, 99],\n",
+       "  [100, 101],\n",
+       "  [100, 110],\n",
+       "  [101, 100],\n",
+       "  [101, 102],\n",
+       "  [102, 92],\n",
+       "  [102, 101],\n",
+       "  [102, 103],\n",
+       "  [103, 102],\n",
+       "  [103, 104],\n",
+       "  [104, 103],\n",
+       "  [104, 105],\n",
+       "  [104, 111],\n",
+       "  [105, 104],\n",
+       "  [105, 106],\n",
+       "  [106, 93],\n",
+       "  [106, 105],\n",
+       "  [106, 107],\n",
+       "  [107, 106],\n",
+       "  [107, 108],\n",
+       "  [108, 107],\n",
+       "  [108, 112],\n",
+       "  [109, 96],\n",
+       "  [109, 114],\n",
+       "  [110, 100],\n",
+       "  [110, 118],\n",
+       "  [111, 104],\n",
+       "  [111, 122],\n",
+       "  [112, 108],\n",
+       "  [112, 126],\n",
+       "  [113, 114],\n",
+       "  [114, 109],\n",
+       "  [114, 113],\n",
+       "  [114, 115],\n",
+       "  [115, 114],\n",
+       "  [115, 116],\n",
+       "  [116, 115],\n",
+       "  [116, 117],\n",
+       "  [117, 116],\n",
+       "  [117, 118],\n",
+       "  [118, 110],\n",
+       "  [118, 117],\n",
+       "  [118, 119],\n",
+       "  [119, 118],\n",
+       "  [119, 120],\n",
+       "  [120, 119],\n",
+       "  [120, 121],\n",
+       "  [121, 120],\n",
+       "  [121, 122],\n",
+       "  [122, 111],\n",
+       "  [122, 121],\n",
+       "  [122, 123],\n",
+       "  [123, 122],\n",
+       "  [123, 124],\n",
+       "  [124, 123],\n",
+       "  [124, 125],\n",
+       "  [125, 124],\n",
+       "  [125, 126],\n",
+       "  [126, 112],\n",
+       "  [126, 125]],\n",
+       " 'description': '127 qubit device',\n",
+       " 'supports_midcircuit_measurement': True,\n",
+       " 'max_experiments': 300,\n",
+       " 'processor_type': {'family': 'Eagle', 'revision': 3}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "backend = provider.get_backend(\"ibmq_brisbane_qpu\")  # selecting the IBM Brisbane device\n",
+    "backend.target_info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "541a58fe",
+   "metadata": {},
+   "source": [
+    "## Job Information\n",
+    "Jobs submitted through Superstaq contain the following information:\n",
+    "\n",
+    "* `job_id()`: Unique identifier for the job.\n",
+    "* `status()`: Status of the job (either Queued, Running, Done).\n",
+    "* `backend()`: Device the job was run on.\n",
+    "* `result().get_counts()`: Counts from the result of the job run. Note that `result()` can take an `index` argument to retrieve a specific job result (corresponding to the circuit with the same `index`). It also optionally accepts a list of qubit indices to retrieve marginal counts on specific qubits via the `qubit_indices` argument of `result()`.\n",
+    "* `input_circuits()`: Retrieves original (i.e., not compiled) circuit(s) for job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
+    "* `compiled_circuits()`: Retrieves compiled circuit(s) from submitted job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
+    "\n",
+    "Note that jobs live in our database for a limited amount of time. Typically, they have a lifespan of 1 year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dbd6a92a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Creating a circuit using Qiskit\n",
+    "qc = qiskit.QuantumCircuit(2, 2)\n",
+    "qc.h(0)\n",
+    "qc.cx(0, 1)\n",
+    "qc.measure([0, 1], [0, 1])\n",
+    "\n",
+    "# Submitting the circuit to the IBM Q QASM Simulator\n",
+    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
+    "job = backend.run(\n",
+    "    [qc], method=\"dry-run\", shots=100\n",
+    ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a4e0461c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'50a836d2-3a2e-4cbb-8bae-5f9108b547f3'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.job_id()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "95d79658",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<JobStatus.DONE: 'job has successfully run'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.status()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "878046e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<SuperstaqBackend('ibmq_qasm_simulator')>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.backend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f8e4e681",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'00': 48, '11': 52}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.result(index=0).get_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6adf4b5b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 454.517x284.278 with 1 Axes>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "job.input_circuits(index=0).draw(output=\"mpl\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c47082b8",
+   "metadata": {},
+   "source": [
+    "You may also retrieve the information described above on a previously submitted `qiskit-superstaq` job:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "16bdcfff",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 454.517x284.278 with 1 Axes>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
+    "job_id = job.job_id()  # Here we use the job ID from above, but this can be any old job ID\n",
+    "job_old = backend.retrieve_job(job_id)\n",
+    "job_old.input_circuits(index=0).draw(output=\"mpl\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/source/get_started/access_info/access_info_qss.ipynb
+++ b/docs/source/get_started/access_info/access_info_qss.ipynb
@@ -1,697 +1,697 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "cf056b55",
-   "metadata": {},
-   "source": [
-    "# Accessing info with `qiskit-superstaq`\n",
-    "This tutorial will cover the information you can access on your account and related jobs and backends using `qiskit-superstaq`."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "70537a94",
-   "metadata": {},
-   "source": [
-    "## Imports and API Token\n",
-    "\n",
-    "As usual, we'll begin with importing requirements and setting up access to Superstaq. This tutorial uses `qiskit-superstaq`, our Superstaq client for Qiskit. You can install it and relevant dependencies by running `pip install qiskit-superstaq[examples]`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "1a637717",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Requirements to use qiskit-superstaq\n",
-    "try:\n",
-    "    import qiskit\n",
-    "    import qiskit_superstaq as qss\n",
-    "except ImportError:\n",
-    "    print(\"Installing qiskit-superstaq...\")\n",
-    "    %pip install --quiet 'qiskit-superstaq[examples]'\n",
-    "    print(\"Installed qiskit-superstaq.\")\n",
-    "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
-    "    import qiskit\n",
-    "    import qiskit_superstaq as qss"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55ead78f",
-   "metadata": {},
-   "source": [
-    "Now, we instantiate a provider in `qiskit-superstaq` with `SuperstaqProvider()`. Supply the Superstaq API token by providing the token as an argument of `qss.SuperstaqProvider()` or setting it as an environment variable (see [this guide](https://superstaq.readthedocs.io/en/latest/get_started/basics/basics_qss.html#Set-up-access-to-Superstaq%E2%80%99s-API))."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "562b5d46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "provider = qss.SuperstaqProvider()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42932197",
-   "metadata": {},
-   "source": [
-    "## Account Information"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "10fc81e6",
-   "metadata": {},
-   "source": [
-    "The `provider` class gives you a means to retrieve information regarding your Superstaq account. Currently, you can use `provider` to retrieve your Superstaq balance."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "f0730b90",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'20 credits'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "provider.get_balance()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "91a268ec",
-   "metadata": {},
-   "source": [
-    "If are interested in increasing your balance or have more information on your user role, please reach out to us at superstaq@infleqtion.com or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "332617c4",
-   "metadata": {},
-   "source": [
-    "## Backend Information\n",
-    "In addition to account information, the ``SuperstaqProvider`` object also gives you a list of all the devices and simulators to which you have access, as well as additional information about those backends.\n",
-    "\n",
-    "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the backends returned: `simulator`, `supports_submit`, `supports_compile`, `available`, and `retired`.\n",
-    "* `backends()`: Retrieves a list of available backends. This method also accepts the same keyword arguments as mentioned above.\n",
-    "* `get_backend(\"<backend_name>\")`: Select your target backend, where `<backend_name>` is the name of the desired backend\n",
-    "* `get_backend(\"<backend_name>\").target_info()`: Retrieve information on your selected backend, such as number of qubits, native gate set"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "7ab7e0ff",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-        "[Target(target='aqt_keysight_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='aqt_zurich_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='aws_dm1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='aws_sv1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='aws_tn1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='cq_hilbert_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='cq_hilbert_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_brisbane_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_extended-stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_kyoto_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_mps_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_osaka_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_qasm_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ibmq_statevector_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ionq_aria-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-        " Target(target='ionq_aria-2_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-        " Target(target='ionq_forte-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-        " Target(target='ionq_harmony_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ionq_ion_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='oxford_lucy_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-        " Target(target='qtm_h1-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='qtm_h1-1e_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='qtm_h2-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='rigetti_aspen-m-3_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
-        " Target(target='qscout_peregrine_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
-        " Target(target='ss_unconstrained_simulator', supports_submit=True, supports_submit_qubo=True, supports_compile=True, available=True, retired=False)]"
-       ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "provider.get_targets()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "58ce4b24",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'backend_name': 'ibmq_brisbane_qpu',\n",
-       " 'backend_version': 'n/a',\n",
-       " 'n_qubits': 127,\n",
-       " 'basis_gates': ['ecr', 'id', 'rz', 'sx', 'x'],\n",
-       " 'gates': [],\n",
-       " 'local': False,\n",
-       " 'simulator': False,\n",
-       " 'conditional': False,\n",
-       " 'open_pulse': True,\n",
-       " 'memory': False,\n",
-       " 'max_shots': 100000,\n",
-       " 'coupling_map': [[0, 1],\n",
-       "  [0, 14],\n",
-       "  [1, 0],\n",
-       "  [1, 2],\n",
-       "  [2, 1],\n",
-       "  [2, 3],\n",
-       "  [3, 2],\n",
-       "  [3, 4],\n",
-       "  [4, 3],\n",
-       "  [4, 5],\n",
-       "  [4, 15],\n",
-       "  [5, 4],\n",
-       "  [5, 6],\n",
-       "  [6, 5],\n",
-       "  [6, 7],\n",
-       "  [7, 6],\n",
-       "  [7, 8],\n",
-       "  [8, 7],\n",
-       "  [8, 9],\n",
-       "  [8, 16],\n",
-       "  [9, 8],\n",
-       "  [9, 10],\n",
-       "  [10, 9],\n",
-       "  [10, 11],\n",
-       "  [11, 10],\n",
-       "  [11, 12],\n",
-       "  [12, 11],\n",
-       "  [12, 13],\n",
-       "  [12, 17],\n",
-       "  [13, 12],\n",
-       "  [14, 0],\n",
-       "  [14, 18],\n",
-       "  [15, 4],\n",
-       "  [15, 22],\n",
-       "  [16, 8],\n",
-       "  [16, 26],\n",
-       "  [17, 12],\n",
-       "  [17, 30],\n",
-       "  [18, 14],\n",
-       "  [18, 19],\n",
-       "  [19, 18],\n",
-       "  [19, 20],\n",
-       "  [20, 19],\n",
-       "  [20, 21],\n",
-       "  [20, 33],\n",
-       "  [21, 20],\n",
-       "  [21, 22],\n",
-       "  [22, 15],\n",
-       "  [22, 21],\n",
-       "  [22, 23],\n",
-       "  [23, 22],\n",
-       "  [23, 24],\n",
-       "  [24, 23],\n",
-       "  [24, 25],\n",
-       "  [24, 34],\n",
-       "  [25, 24],\n",
-       "  [25, 26],\n",
-       "  [26, 16],\n",
-       "  [26, 25],\n",
-       "  [26, 27],\n",
-       "  [27, 26],\n",
-       "  [27, 28],\n",
-       "  [28, 27],\n",
-       "  [28, 29],\n",
-       "  [28, 35],\n",
-       "  [29, 28],\n",
-       "  [29, 30],\n",
-       "  [30, 17],\n",
-       "  [30, 29],\n",
-       "  [30, 31],\n",
-       "  [31, 30],\n",
-       "  [31, 32],\n",
-       "  [32, 31],\n",
-       "  [32, 36],\n",
-       "  [33, 20],\n",
-       "  [33, 39],\n",
-       "  [34, 24],\n",
-       "  [34, 43],\n",
-       "  [35, 28],\n",
-       "  [35, 47],\n",
-       "  [36, 32],\n",
-       "  [36, 51],\n",
-       "  [37, 38],\n",
-       "  [37, 52],\n",
-       "  [38, 37],\n",
-       "  [38, 39],\n",
-       "  [39, 33],\n",
-       "  [39, 38],\n",
-       "  [39, 40],\n",
-       "  [40, 39],\n",
-       "  [40, 41],\n",
-       "  [41, 40],\n",
-       "  [41, 42],\n",
-       "  [41, 53],\n",
-       "  [42, 41],\n",
-       "  [42, 43],\n",
-       "  [43, 34],\n",
-       "  [43, 42],\n",
-       "  [43, 44],\n",
-       "  [44, 43],\n",
-       "  [44, 45],\n",
-       "  [45, 44],\n",
-       "  [45, 46],\n",
-       "  [45, 54],\n",
-       "  [46, 45],\n",
-       "  [46, 47],\n",
-       "  [47, 35],\n",
-       "  [47, 46],\n",
-       "  [47, 48],\n",
-       "  [48, 47],\n",
-       "  [48, 49],\n",
-       "  [49, 48],\n",
-       "  [49, 50],\n",
-       "  [49, 55],\n",
-       "  [50, 49],\n",
-       "  [50, 51],\n",
-       "  [51, 36],\n",
-       "  [51, 50],\n",
-       "  [52, 37],\n",
-       "  [52, 56],\n",
-       "  [53, 41],\n",
-       "  [53, 60],\n",
-       "  [54, 45],\n",
-       "  [54, 64],\n",
-       "  [55, 49],\n",
-       "  [55, 68],\n",
-       "  [56, 52],\n",
-       "  [56, 57],\n",
-       "  [57, 56],\n",
-       "  [57, 58],\n",
-       "  [58, 57],\n",
-       "  [58, 59],\n",
-       "  [58, 71],\n",
-       "  [59, 58],\n",
-       "  [59, 60],\n",
-       "  [60, 53],\n",
-       "  [60, 59],\n",
-       "  [60, 61],\n",
-       "  [61, 60],\n",
-       "  [61, 62],\n",
-       "  [62, 61],\n",
-       "  [62, 63],\n",
-       "  [62, 72],\n",
-       "  [63, 62],\n",
-       "  [63, 64],\n",
-       "  [64, 54],\n",
-       "  [64, 63],\n",
-       "  [64, 65],\n",
-       "  [65, 64],\n",
-       "  [65, 66],\n",
-       "  [66, 65],\n",
-       "  [66, 67],\n",
-       "  [66, 73],\n",
-       "  [67, 66],\n",
-       "  [67, 68],\n",
-       "  [68, 55],\n",
-       "  [68, 67],\n",
-       "  [68, 69],\n",
-       "  [69, 68],\n",
-       "  [69, 70],\n",
-       "  [70, 69],\n",
-       "  [70, 74],\n",
-       "  [71, 58],\n",
-       "  [71, 77],\n",
-       "  [72, 62],\n",
-       "  [72, 81],\n",
-       "  [73, 66],\n",
-       "  [73, 85],\n",
-       "  [74, 70],\n",
-       "  [74, 89],\n",
-       "  [75, 76],\n",
-       "  [75, 90],\n",
-       "  [76, 75],\n",
-       "  [76, 77],\n",
-       "  [77, 71],\n",
-       "  [77, 76],\n",
-       "  [77, 78],\n",
-       "  [78, 77],\n",
-       "  [78, 79],\n",
-       "  [79, 78],\n",
-       "  [79, 80],\n",
-       "  [79, 91],\n",
-       "  [80, 79],\n",
-       "  [80, 81],\n",
-       "  [81, 72],\n",
-       "  [81, 80],\n",
-       "  [81, 82],\n",
-       "  [82, 81],\n",
-       "  [82, 83],\n",
-       "  [83, 82],\n",
-       "  [83, 84],\n",
-       "  [83, 92],\n",
-       "  [84, 83],\n",
-       "  [84, 85],\n",
-       "  [85, 73],\n",
-       "  [85, 84],\n",
-       "  [85, 86],\n",
-       "  [86, 85],\n",
-       "  [86, 87],\n",
-       "  [87, 86],\n",
-       "  [87, 88],\n",
-       "  [87, 93],\n",
-       "  [88, 87],\n",
-       "  [88, 89],\n",
-       "  [89, 74],\n",
-       "  [89, 88],\n",
-       "  [90, 75],\n",
-       "  [90, 94],\n",
-       "  [91, 79],\n",
-       "  [91, 98],\n",
-       "  [92, 83],\n",
-       "  [92, 102],\n",
-       "  [93, 87],\n",
-       "  [93, 106],\n",
-       "  [94, 90],\n",
-       "  [94, 95],\n",
-       "  [95, 94],\n",
-       "  [95, 96],\n",
-       "  [96, 95],\n",
-       "  [96, 97],\n",
-       "  [96, 109],\n",
-       "  [97, 96],\n",
-       "  [97, 98],\n",
-       "  [98, 91],\n",
-       "  [98, 97],\n",
-       "  [98, 99],\n",
-       "  [99, 98],\n",
-       "  [99, 100],\n",
-       "  [100, 99],\n",
-       "  [100, 101],\n",
-       "  [100, 110],\n",
-       "  [101, 100],\n",
-       "  [101, 102],\n",
-       "  [102, 92],\n",
-       "  [102, 101],\n",
-       "  [102, 103],\n",
-       "  [103, 102],\n",
-       "  [103, 104],\n",
-       "  [104, 103],\n",
-       "  [104, 105],\n",
-       "  [104, 111],\n",
-       "  [105, 104],\n",
-       "  [105, 106],\n",
-       "  [106, 93],\n",
-       "  [106, 105],\n",
-       "  [106, 107],\n",
-       "  [107, 106],\n",
-       "  [107, 108],\n",
-       "  [108, 107],\n",
-       "  [108, 112],\n",
-       "  [109, 96],\n",
-       "  [109, 114],\n",
-       "  [110, 100],\n",
-       "  [110, 118],\n",
-       "  [111, 104],\n",
-       "  [111, 122],\n",
-       "  [112, 108],\n",
-       "  [112, 126],\n",
-       "  [113, 114],\n",
-       "  [114, 109],\n",
-       "  [114, 113],\n",
-       "  [114, 115],\n",
-       "  [115, 114],\n",
-       "  [115, 116],\n",
-       "  [116, 115],\n",
-       "  [116, 117],\n",
-       "  [117, 116],\n",
-       "  [117, 118],\n",
-       "  [118, 110],\n",
-       "  [118, 117],\n",
-       "  [118, 119],\n",
-       "  [119, 118],\n",
-       "  [119, 120],\n",
-       "  [120, 119],\n",
-       "  [120, 121],\n",
-       "  [121, 120],\n",
-       "  [121, 122],\n",
-       "  [122, 111],\n",
-       "  [122, 121],\n",
-       "  [122, 123],\n",
-       "  [123, 122],\n",
-       "  [123, 124],\n",
-       "  [124, 123],\n",
-       "  [124, 125],\n",
-       "  [125, 124],\n",
-       "  [125, 126],\n",
-       "  [126, 112],\n",
-       "  [126, 125]],\n",
-       " 'description': '127 qubit device',\n",
-       " 'supports_midcircuit_measurement': True,\n",
-       " 'max_experiments': 300,\n",
-       " 'processor_type': {'family': 'Eagle', 'revision': 3}}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "backend = provider.get_backend(\"ibmq_brisbane_qpu\")  # selecting the IBM Brisbane device\n",
-    "backend.target_info()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "541a58fe",
-   "metadata": {},
-   "source": [
-    "## Job Information\n",
-    "Jobs submitted through Superstaq contain the following information:\n",
-    "\n",
-    "* `job_id()`: Unique identifier for the job.\n",
-    "* `status()`: Status of the job (either Queued, Running, Done).\n",
-    "* `backend()`: Device the job was run on.\n",
-    "* `result().get_counts()`: Counts from the result of the job run. Note that `result()` can take an `index` argument to retrieve a specific job result (corresponding to the circuit with the same `index`). It also optionally accepts a list of qubit indices to retrieve marginal counts on specific qubits via the `qubit_indices` argument of `result()`.\n",
-    "* `input_circuits()`: Retrieves original (i.e., not compiled) circuit(s) for job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
-    "* `compiled_circuits()`: Retrieves compiled circuit(s) from submitted job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
-    "\n",
-    "Note that jobs live in our database for a limited amount of time. Typically, they have a lifespan of 1 year."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "dbd6a92a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Creating a circuit using Qiskit\n",
-    "qc = qiskit.QuantumCircuit(2, 2)\n",
-    "qc.h(0)\n",
-    "qc.cx(0, 1)\n",
-    "qc.measure([0, 1], [0, 1])\n",
-    "\n",
-    "# Submitting the circuit to the IBM Q QASM Simulator\n",
-    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-    "job = backend.run(\n",
-    "    [qc], method=\"dry-run\", shots=100\n",
-    ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "a4e0461c",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'50a836d2-3a2e-4cbb-8bae-5f9108b547f3'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "job.job_id()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "95d79658",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<JobStatus.DONE: 'job has successfully run'>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "job.status()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "878046e1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<SuperstaqBackend('ibmq_qasm_simulator')>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "job.backend()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "f8e4e681",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'00': 48, '11': 52}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "job.result(index=0).get_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "6adf4b5b",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 454.517x284.278 with 1 Axes>"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "job.input_circuits(index=0).draw(output=\"mpl\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c47082b8",
-   "metadata": {},
-   "source": [
-    "You may also retrieve the information described above on a previously submitted `qiskit-superstaq` job:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "16bdcfff",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 454.517x284.278 with 1 Axes>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
-    "job_id = job.job_id()  # Here we use the job ID from above, but this can be any old job ID\n",
-    "job_old = backend.retrieve_job(job_id)\n",
-    "job_old.input_circuits(index=0).draw(output=\"mpl\")"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.16"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "cf056b55",
+            "metadata": {},
+            "source": [
+                "# Accessing info with `qiskit-superstaq`\n",
+                "This tutorial will cover the information you can access on your account and related jobs and backends using `qiskit-superstaq`."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "70537a94",
+            "metadata": {},
+            "source": [
+                "## Imports and API Token\n",
+                "\n",
+                "As usual, we'll begin with importing requirements and setting up access to Superstaq. This tutorial uses `qiskit-superstaq`, our Superstaq client for Qiskit. You can install it and relevant dependencies by running `pip install qiskit-superstaq[examples]`."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "1a637717",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Requirements to use qiskit-superstaq\n",
+                "try:\n",
+                "    import qiskit\n",
+                "    import qiskit_superstaq as qss\n",
+                "except ImportError:\n",
+                "    print(\"Installing qiskit-superstaq...\")\n",
+                "    %pip install --quiet 'qiskit-superstaq[examples]'\n",
+                "    print(\"Installed qiskit-superstaq.\")\n",
+                "    print(\"You may need to restart the kernel to import newly installed packages.\")\n",
+                "    import qiskit\n",
+                "    import qiskit_superstaq as qss"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "55ead78f",
+            "metadata": {},
+            "source": [
+                "Now, we instantiate a provider in `qiskit-superstaq` with `SuperstaqProvider()`. Supply the Superstaq API token by providing the token as an argument of `qss.SuperstaqProvider()` or setting it as an environment variable (see [this guide](https://superstaq.readthedocs.io/en/latest/get_started/basics/basics_qss.html#Set-up-access-to-Superstaq%E2%80%99s-API))."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "562b5d46",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "provider = qss.SuperstaqProvider()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "42932197",
+            "metadata": {},
+            "source": [
+                "## Account Information"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "10fc81e6",
+            "metadata": {},
+            "source": [
+                "The `provider` class gives you a means to retrieve information regarding your Superstaq account. Currently, you can use `provider` to retrieve your Superstaq balance."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "f0730b90",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "'20 credits'"
+                        ]
+                    },
+                    "execution_count": 3,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "provider.get_balance()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "91a268ec",
+            "metadata": {},
+            "source": [
+                "If are interested in increasing your balance or have more information on your user role, please reach out to us at superstaq@infleqtion.com or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "332617c4",
+            "metadata": {},
+            "source": [
+                "## Backend Information\n",
+                "In addition to account information, the ``SuperstaqProvider`` object also gives you a list of all the devices and simulators to which you have access, as well as additional information about those backends.\n",
+                "\n",
+                "* `get_targets()`: Retrieves a list of supported Superstaq targets. This method also accepts the following boolean keyword arguments to filter the targets returned: `simulator`, `supports_submit`, `supports_submit_qubo`, `supports_compile`, `available`, and `retired`.\n",
+                "* `backends()`: Retrieves a list of available backends. This method also accepts the same keyword arguments as mentioned above.\n",
+                "* `get_backend(\"<backend_name>\")`: Select your target backend, where `<backend_name>` is the name of the desired backend\n",
+                "* `get_backend(\"<backend_name>\").target_info()`: Retrieve information on your selected backend, such as number of qubits, native gate set"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "7ab7e0ff",
+            "metadata": {
+                "scrolled": false
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "[Target(target='aqt_keysight_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='aqt_zurich_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='aws_dm1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='aws_sv1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='aws_tn1_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='cq_hilbert_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='cq_hilbert_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_brisbane_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_extended-stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_kyoto_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_mps_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_osaka_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_qasm_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_stabilizer_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ibmq_statevector_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ionq_aria-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+                            " Target(target='ionq_aria-2_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+                            " Target(target='ionq_forte-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+                            " Target(target='ionq_harmony_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ionq_ion_simulator', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='oxford_lucy_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+                            " Target(target='qtm_h1-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='qtm_h1-1e_simulator', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='qtm_h2-1_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='rigetti_aspen-m-3_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=False, retired=False),\n",
+                            " Target(target='qscout_peregrine_qpu', supports_submit=False, supports_submit_qubo=False, supports_compile=True, available=True, retired=False),\n",
+                            " Target(target='ss_unconstrained_simulator', supports_submit=True, supports_submit_qubo=True, supports_compile=True, available=True, retired=False)]"
+                        ]
+                    },
+                    "execution_count": 4,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "provider.get_targets()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "58ce4b24",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "{'backend_name': 'ibmq_brisbane_qpu',\n",
+                            " 'backend_version': 'n/a',\n",
+                            " 'n_qubits': 127,\n",
+                            " 'basis_gates': ['ecr', 'id', 'rz', 'sx', 'x'],\n",
+                            " 'gates': [],\n",
+                            " 'local': False,\n",
+                            " 'simulator': False,\n",
+                            " 'conditional': False,\n",
+                            " 'open_pulse': True,\n",
+                            " 'memory': False,\n",
+                            " 'max_shots': 100000,\n",
+                            " 'coupling_map': [[0, 1],\n",
+                            "  [0, 14],\n",
+                            "  [1, 0],\n",
+                            "  [1, 2],\n",
+                            "  [2, 1],\n",
+                            "  [2, 3],\n",
+                            "  [3, 2],\n",
+                            "  [3, 4],\n",
+                            "  [4, 3],\n",
+                            "  [4, 5],\n",
+                            "  [4, 15],\n",
+                            "  [5, 4],\n",
+                            "  [5, 6],\n",
+                            "  [6, 5],\n",
+                            "  [6, 7],\n",
+                            "  [7, 6],\n",
+                            "  [7, 8],\n",
+                            "  [8, 7],\n",
+                            "  [8, 9],\n",
+                            "  [8, 16],\n",
+                            "  [9, 8],\n",
+                            "  [9, 10],\n",
+                            "  [10, 9],\n",
+                            "  [10, 11],\n",
+                            "  [11, 10],\n",
+                            "  [11, 12],\n",
+                            "  [12, 11],\n",
+                            "  [12, 13],\n",
+                            "  [12, 17],\n",
+                            "  [13, 12],\n",
+                            "  [14, 0],\n",
+                            "  [14, 18],\n",
+                            "  [15, 4],\n",
+                            "  [15, 22],\n",
+                            "  [16, 8],\n",
+                            "  [16, 26],\n",
+                            "  [17, 12],\n",
+                            "  [17, 30],\n",
+                            "  [18, 14],\n",
+                            "  [18, 19],\n",
+                            "  [19, 18],\n",
+                            "  [19, 20],\n",
+                            "  [20, 19],\n",
+                            "  [20, 21],\n",
+                            "  [20, 33],\n",
+                            "  [21, 20],\n",
+                            "  [21, 22],\n",
+                            "  [22, 15],\n",
+                            "  [22, 21],\n",
+                            "  [22, 23],\n",
+                            "  [23, 22],\n",
+                            "  [23, 24],\n",
+                            "  [24, 23],\n",
+                            "  [24, 25],\n",
+                            "  [24, 34],\n",
+                            "  [25, 24],\n",
+                            "  [25, 26],\n",
+                            "  [26, 16],\n",
+                            "  [26, 25],\n",
+                            "  [26, 27],\n",
+                            "  [27, 26],\n",
+                            "  [27, 28],\n",
+                            "  [28, 27],\n",
+                            "  [28, 29],\n",
+                            "  [28, 35],\n",
+                            "  [29, 28],\n",
+                            "  [29, 30],\n",
+                            "  [30, 17],\n",
+                            "  [30, 29],\n",
+                            "  [30, 31],\n",
+                            "  [31, 30],\n",
+                            "  [31, 32],\n",
+                            "  [32, 31],\n",
+                            "  [32, 36],\n",
+                            "  [33, 20],\n",
+                            "  [33, 39],\n",
+                            "  [34, 24],\n",
+                            "  [34, 43],\n",
+                            "  [35, 28],\n",
+                            "  [35, 47],\n",
+                            "  [36, 32],\n",
+                            "  [36, 51],\n",
+                            "  [37, 38],\n",
+                            "  [37, 52],\n",
+                            "  [38, 37],\n",
+                            "  [38, 39],\n",
+                            "  [39, 33],\n",
+                            "  [39, 38],\n",
+                            "  [39, 40],\n",
+                            "  [40, 39],\n",
+                            "  [40, 41],\n",
+                            "  [41, 40],\n",
+                            "  [41, 42],\n",
+                            "  [41, 53],\n",
+                            "  [42, 41],\n",
+                            "  [42, 43],\n",
+                            "  [43, 34],\n",
+                            "  [43, 42],\n",
+                            "  [43, 44],\n",
+                            "  [44, 43],\n",
+                            "  [44, 45],\n",
+                            "  [45, 44],\n",
+                            "  [45, 46],\n",
+                            "  [45, 54],\n",
+                            "  [46, 45],\n",
+                            "  [46, 47],\n",
+                            "  [47, 35],\n",
+                            "  [47, 46],\n",
+                            "  [47, 48],\n",
+                            "  [48, 47],\n",
+                            "  [48, 49],\n",
+                            "  [49, 48],\n",
+                            "  [49, 50],\n",
+                            "  [49, 55],\n",
+                            "  [50, 49],\n",
+                            "  [50, 51],\n",
+                            "  [51, 36],\n",
+                            "  [51, 50],\n",
+                            "  [52, 37],\n",
+                            "  [52, 56],\n",
+                            "  [53, 41],\n",
+                            "  [53, 60],\n",
+                            "  [54, 45],\n",
+                            "  [54, 64],\n",
+                            "  [55, 49],\n",
+                            "  [55, 68],\n",
+                            "  [56, 52],\n",
+                            "  [56, 57],\n",
+                            "  [57, 56],\n",
+                            "  [57, 58],\n",
+                            "  [58, 57],\n",
+                            "  [58, 59],\n",
+                            "  [58, 71],\n",
+                            "  [59, 58],\n",
+                            "  [59, 60],\n",
+                            "  [60, 53],\n",
+                            "  [60, 59],\n",
+                            "  [60, 61],\n",
+                            "  [61, 60],\n",
+                            "  [61, 62],\n",
+                            "  [62, 61],\n",
+                            "  [62, 63],\n",
+                            "  [62, 72],\n",
+                            "  [63, 62],\n",
+                            "  [63, 64],\n",
+                            "  [64, 54],\n",
+                            "  [64, 63],\n",
+                            "  [64, 65],\n",
+                            "  [65, 64],\n",
+                            "  [65, 66],\n",
+                            "  [66, 65],\n",
+                            "  [66, 67],\n",
+                            "  [66, 73],\n",
+                            "  [67, 66],\n",
+                            "  [67, 68],\n",
+                            "  [68, 55],\n",
+                            "  [68, 67],\n",
+                            "  [68, 69],\n",
+                            "  [69, 68],\n",
+                            "  [69, 70],\n",
+                            "  [70, 69],\n",
+                            "  [70, 74],\n",
+                            "  [71, 58],\n",
+                            "  [71, 77],\n",
+                            "  [72, 62],\n",
+                            "  [72, 81],\n",
+                            "  [73, 66],\n",
+                            "  [73, 85],\n",
+                            "  [74, 70],\n",
+                            "  [74, 89],\n",
+                            "  [75, 76],\n",
+                            "  [75, 90],\n",
+                            "  [76, 75],\n",
+                            "  [76, 77],\n",
+                            "  [77, 71],\n",
+                            "  [77, 76],\n",
+                            "  [77, 78],\n",
+                            "  [78, 77],\n",
+                            "  [78, 79],\n",
+                            "  [79, 78],\n",
+                            "  [79, 80],\n",
+                            "  [79, 91],\n",
+                            "  [80, 79],\n",
+                            "  [80, 81],\n",
+                            "  [81, 72],\n",
+                            "  [81, 80],\n",
+                            "  [81, 82],\n",
+                            "  [82, 81],\n",
+                            "  [82, 83],\n",
+                            "  [83, 82],\n",
+                            "  [83, 84],\n",
+                            "  [83, 92],\n",
+                            "  [84, 83],\n",
+                            "  [84, 85],\n",
+                            "  [85, 73],\n",
+                            "  [85, 84],\n",
+                            "  [85, 86],\n",
+                            "  [86, 85],\n",
+                            "  [86, 87],\n",
+                            "  [87, 86],\n",
+                            "  [87, 88],\n",
+                            "  [87, 93],\n",
+                            "  [88, 87],\n",
+                            "  [88, 89],\n",
+                            "  [89, 74],\n",
+                            "  [89, 88],\n",
+                            "  [90, 75],\n",
+                            "  [90, 94],\n",
+                            "  [91, 79],\n",
+                            "  [91, 98],\n",
+                            "  [92, 83],\n",
+                            "  [92, 102],\n",
+                            "  [93, 87],\n",
+                            "  [93, 106],\n",
+                            "  [94, 90],\n",
+                            "  [94, 95],\n",
+                            "  [95, 94],\n",
+                            "  [95, 96],\n",
+                            "  [96, 95],\n",
+                            "  [96, 97],\n",
+                            "  [96, 109],\n",
+                            "  [97, 96],\n",
+                            "  [97, 98],\n",
+                            "  [98, 91],\n",
+                            "  [98, 97],\n",
+                            "  [98, 99],\n",
+                            "  [99, 98],\n",
+                            "  [99, 100],\n",
+                            "  [100, 99],\n",
+                            "  [100, 101],\n",
+                            "  [100, 110],\n",
+                            "  [101, 100],\n",
+                            "  [101, 102],\n",
+                            "  [102, 92],\n",
+                            "  [102, 101],\n",
+                            "  [102, 103],\n",
+                            "  [103, 102],\n",
+                            "  [103, 104],\n",
+                            "  [104, 103],\n",
+                            "  [104, 105],\n",
+                            "  [104, 111],\n",
+                            "  [105, 104],\n",
+                            "  [105, 106],\n",
+                            "  [106, 93],\n",
+                            "  [106, 105],\n",
+                            "  [106, 107],\n",
+                            "  [107, 106],\n",
+                            "  [107, 108],\n",
+                            "  [108, 107],\n",
+                            "  [108, 112],\n",
+                            "  [109, 96],\n",
+                            "  [109, 114],\n",
+                            "  [110, 100],\n",
+                            "  [110, 118],\n",
+                            "  [111, 104],\n",
+                            "  [111, 122],\n",
+                            "  [112, 108],\n",
+                            "  [112, 126],\n",
+                            "  [113, 114],\n",
+                            "  [114, 109],\n",
+                            "  [114, 113],\n",
+                            "  [114, 115],\n",
+                            "  [115, 114],\n",
+                            "  [115, 116],\n",
+                            "  [116, 115],\n",
+                            "  [116, 117],\n",
+                            "  [117, 116],\n",
+                            "  [117, 118],\n",
+                            "  [118, 110],\n",
+                            "  [118, 117],\n",
+                            "  [118, 119],\n",
+                            "  [119, 118],\n",
+                            "  [119, 120],\n",
+                            "  [120, 119],\n",
+                            "  [120, 121],\n",
+                            "  [121, 120],\n",
+                            "  [121, 122],\n",
+                            "  [122, 111],\n",
+                            "  [122, 121],\n",
+                            "  [122, 123],\n",
+                            "  [123, 122],\n",
+                            "  [123, 124],\n",
+                            "  [124, 123],\n",
+                            "  [124, 125],\n",
+                            "  [125, 124],\n",
+                            "  [125, 126],\n",
+                            "  [126, 112],\n",
+                            "  [126, 125]],\n",
+                            " 'description': '127 qubit device',\n",
+                            " 'supports_midcircuit_measurement': True,\n",
+                            " 'max_experiments': 300,\n",
+                            " 'processor_type': {'family': 'Eagle', 'revision': 3}}"
+                        ]
+                    },
+                    "execution_count": 5,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "backend = provider.get_backend(\"ibmq_brisbane_qpu\")  # selecting the IBM Brisbane device\n",
+                "backend.target_info()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "541a58fe",
+            "metadata": {},
+            "source": [
+                "## Job Information\n",
+                "Jobs submitted through Superstaq contain the following information:\n",
+                "\n",
+                "* `job_id()`: Unique identifier for the job.\n",
+                "* `status()`: Status of the job (either Queued, Running, Done).\n",
+                "* `backend()`: Device the job was run on.\n",
+                "* `result().get_counts()`: Counts from the result of the job run. Note that `result()` can take an `index` argument to retrieve a specific job result (corresponding to the circuit with the same `index`). It also optionally accepts a list of qubit indices to retrieve marginal counts on specific qubits via the `qubit_indices` argument of `result()`.\n",
+                "* `input_circuits()`: Retrieves original (i.e., not compiled) circuit(s) for job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
+                "* `compiled_circuits()`: Retrieves compiled circuit(s) from submitted job. Note this returns a list and you must specify an `index` if you want to retrieve a single/specific circuit.\n",
+                "\n",
+                "Note that jobs live in our database for a limited amount of time. Typically, they have a lifespan of 1 year."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "dbd6a92a",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Creating a circuit using Qiskit\n",
+                "qc = qiskit.QuantumCircuit(2, 2)\n",
+                "qc.h(0)\n",
+                "qc.cx(0, 1)\n",
+                "qc.measure([0, 1], [0, 1])\n",
+                "\n",
+                "# Submitting the circuit to the IBM Q QASM Simulator\n",
+                "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
+                "job = backend.run(\n",
+                "    [qc], method=\"dry-run\", shots=100\n",
+                ")  # Specify \"dry-run\" as the method to submit & run a Superstaq simulation"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "a4e0461c",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "'50a836d2-3a2e-4cbb-8bae-5f9108b547f3'"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "job.job_id()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "95d79658",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "<JobStatus.DONE: 'job has successfully run'>"
+                        ]
+                    },
+                    "execution_count": 8,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "job.status()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "878046e1",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "<SuperstaqBackend('ibmq_qasm_simulator')>"
+                        ]
+                    },
+                    "execution_count": 9,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "job.backend()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "f8e4e681",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/plain": [
+                            "{'00': 48, '11': 52}"
+                        ]
+                    },
+                    "execution_count": 10,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "job.result(index=0).get_counts()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "6adf4b5b",
+            "metadata": {
+                "scrolled": true
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<Figure size 454.517x284.278 with 1 Axes>"
+                        ]
+                    },
+                    "execution_count": 11,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "job.input_circuits(index=0).draw(output=\"mpl\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c47082b8",
+            "metadata": {},
+            "source": [
+                "You may also retrieve the information described above on a previously submitted `qiskit-superstaq` job:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "16bdcfff",
+            "metadata": {},
+            "outputs": [
+                {
+                    "data": {
+                        "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAADuCAYAAADPwDeGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAdm0lEQVR4nO3de3SU5b328W/OJxKSAJpAAgEBBQIBAmwTqRoKchaworZU0IqKxQqtJSjuqnRZEKGu97VuKgjVasuhKrUWEKhFhVJAAgRBzmhsEjJsA4EwCRGSyf5jmpSQCWQmM5m5J9dnLVYyz+F+fgPDNfdzP6eA6urqakRExEiB3i5ARERcpxAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMFuztAqS+6mq4WOXtKpwTGgQBAd6uwn9UV1dTXl7u7TKcEhkZSYA+BM1OIe6DLlbB7NXersI5C+6FMH2a3Ka8vJxWrVp5uwynWK1WoqKivF1Gi6PhFBERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXaSHatGlD586d6dKlCwkJCU6vP23aNJKTkz1QmTSF7nYh4qeSkpKYPHkyN998M+np6bRv377O/LNnz7Jnzx527drFypUr2bdvX4NtPf3008ybN48TJ06QlZVFfn6+p8uXRlJPXMTPDB48mDVr1pCXl8evfvUrxo4dWy/AAWJjYxkyZAizZ88mNzeXbdu2ce+999ZbribAAW644QZGjhzp8fcgjef3IV5cXEx2djZdu3YlPDyc5ORkZsyYQVlZGQ899BABAQG8+uqr3i5TPMhmgwMFsGI7vP4JvLkVNu6Hcxe8XZl7tWrVit/+9rds3bqVCRMmEBQUVDuvpKSEv//976xYsYI//vGPrFu3joKCgjrrZ2ZmsmrVKjZt2kTHjh2BugEOkJ2dzdKlS5vnDUmj+PVwSm5uLiNHjsRisRAVFUXPnj05efIkr7zyCidOnODMmTMA9O3b17uFekjBwU94b14Wg7+/kPTRP3e4zP//YQApfUcz7udrm7m65rHzBGz4HEquuDV37r/sQZ7WEe4eCFFh3qnPXfr378+aNWvo1KlT7bTCwkKWLl3KihUrOH78uMP1EhISGDduHD/+8Y/p06cPAMOGDePAgQOsXbuW73//+7XLZmdns3DhQs++EXGa3/bEi4uLGTt2LBaLhSeffJKioiL27NmDxWJhwYIFrFu3jl27dhEQEFD74RX/smE/rNxRP8Br2Kph79fw/zZCqcG98szMTD7++OPaALdarUyfPp2UlBR++ctfNhjgABaLhSVLlpCWlsaoUaNqx7qjo6MV4Ibw2xB/4oknKCgo4PHHH2fRokVER0fXzsvOziYtLY3KykpSUlKIiYnxYqXiCXvy7D3wxvjmPCz71B7qpunduzfr16+v/Qz/85//pHfv3ixevJjKykqn2vrwww9JTU1l7969dab/4Q9/UID7ML8M8UOHDrF69Wratm3L/PnzHS6Tnp4OQFpaWp3pX331FXfeeSfR0dHExcUxefJkTp8+7fGaxX2qq+FvB5xb51+n4ajFM/V4SmhoKCtWrKB169YAbNy4kaFDh5KXl+dym9OnT6dfv351pt155506tdCH+WWIr1y5EpvNxqRJkxp8xFVERARQN8TPnz9PVlYWBQUFrFy5kqVLl7J161bGjBmDzWZrlto9ofJiORfOFzv844++/AaKzjm/3j+Our8WT3r22WdJTU0FYO/evdx1111cuOD6uNCVBzF3794NQExMDMuWLWtaseIxfnlgc/PmzQBkZWU1uEzNkfnLQ3zp0qUUFhayZcuW2qPzSUlJZGZm8sEHHzB+/HjPFe1BO957jh3vPeftMprN4ZOurXfopL0Xb8Kzfrt27crs2bMBuHjxIpMnT27Sg5UdnYWyZMkSDhw4QHJyMnfccQcTJ07knXfeaXLt4l5+GeJff/01QJ0j9ZerrKxk27ZtQN0QX7t2LYMHD64NcICMjAy6dOnCX//6V5dDfMCAAVgsjd9XDwqJYMILx1zaliOpWY/Q7b8mOpz35xeHuWUb3bt1o+qSbxwd7DvuBbpmPuD0elU26NT5BmyV37q/KCdda8/vscceIzjY/t93/vz5HDjg5PjRZRwFeM0Y+LRp01i3bh0AP/nJT64a4t26dSMw0C937ptFQkICOTk5Tq/nlyFeVlYG0OCu5erVqykuLiY6OprOnTvXTj948CATJ9YPu169enHw4EGX67FYLBQWFjZ6+eCwSJe35UhsQjc6pg51a5tXOll0kspvXe8JulPKmf91aT1bVSX5X3/p5mrcLyIiggcffBCwf8ZfeeUVl9u6WoADrF+/ngMHDpCamsp3vvMdevfuzf79+x22VVRU5HId4jq/DPGEhARKSkrYs2cPGRkZdeYVFRUxa9YsAPr06UPAZfvOJSUlxMbG1msvPj6eI0eONKkeZwSFRLi8LW9pn9jeZ3ril86ecGm9koJ9dOjQwc3VuMZmszUYiiNGjCAuLg6AVatW1V7v4KxrBXiNxYsXs3jxYgB+8IMf8PTTTztsLzExUT3xJnDlfjbgpyE+dOhQDh06xIIFCxg2bBjdu3cHYNeuXdx///0UF9sP6DXXRT7O7iJ9WwmzV3uoGA85euwYYT7yaaqywdz3nT/3+4n70nl7TsG1F2wGZWVlDR6UHzBgQO3vf/nLX1xqv7EBXrONmhC/fNtXOnbsGFFRUS7VI67zy6/N7Oxs2rRpQ35+Pr169aJ3795069aNQYMG0aVLF4YMGQLUP70wLi6Os2fP1mvvzJkzxMfHN0fp4gZBgTC4u3PrxERAX8eHUHxOzemx4HwHAZwLcICTJ0/W7hX079/f6e2JZ/lliCclJbF161ZGjx5NeHg4eXl5xMfHs2TJEtatW8fRo/Zzya4M8R49ejgc+z548CA9evRoltrFPb7bE1KTGrdsWDBMvQ1Cgq69rC+46aabADh9+rRTx1rA+QCvkZubC9iHFq+//nqntime5SM7wO7Xo0cP1q6tfz8Qq9VKXl4egYGBtefY1hgzZgxz5syhoKCApCR7AuzcuZMTJ07oijXDBAXCA4PhvRzYcRwauhizTSt48DuQZNCOlsViITAw0KkzngBmzZrlUoAD5OfnU1hYyIULF2rPihHfEFBdXW3gxcau27lzJzfffDM33ngjhw8frjOvtLSU3r1707ZtW+bOnUtFRQXZ2dm0a9eO7du3N9tBGxPHxBfci8+MiV/ptBW2H4fP8+GbUnugBwfCg7dCj0TwxWNxVxsTd9Xw4cN5//33CQ8P98i9UKxWq8bEvcAHP76eVXN61JVDKWC/Mm3z5s0kJiZy3333MXXqVDIzM1m7dq2OuhusTSsY0xfmjLWPfYP9roW9OvhmgHvKxo0bGT9+PE8++aT2LP2Ij/adPOdqIQ72m947GoYR8QcbN25k48aN3i5D3KgF9UPsrhXiIiImaXE98Zr7qoiI+IMW1xMXEfEnCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDKYQFxExmEJcRMRgCnEREYMpxEVEDNbi7p1igtAg+/25TRJqyFNxTBEZGYnVanVbewuXrKK0rJyYqEhmPXpfvdfuEBkZ6ZZ2xDkKcR8UEOC7D1iQ5hEQEODWByyEhoUTeqmK0LBwoqKi6r0Wc2k4RUTEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYApxERGDKcRFRAymEBcRMZhCXETEYHp+jIj4pOrqasrLy71dRqNFRkYSEBDQ7NtViIuITyovL6dVq1beLqPRrFarVx51p+EUERGDKcRFRAymEBcRMZhCXETEYApxaTFs1VBdbf+95qeI6XR2ivitU+fg83woOAP5Z+BM2X/mlVbAK5sgKR5uuA56dYDgIO/VKuIqhbj4FVs17M+HfxyFY6euvuyX39j/bDkC0eGQ0RVu6Q6tI5qnVhF3UIiL3zhthVU7rh3ejpyvgE0H7IE+IR0GdQEvXLch4jSFuPiFz76Ed3fBxcqmtVNxCVbugH3/gh9mQmSYe+oT8RQd2BTjfXwIVmxveoBf7uBJePUjsFa4r00RT1CIi9H+cRT+ssczbZ88C69ttvfORUJCQkhISPB2GfVoOEWMVXAG1uR4eBsl8Ofd8P2bPbsd8YyIiAgGDBhAeno66enpJCYmEhoaysWLFzl58iS7d+9m9+7d5OTkUFHR8G5XSEgI77zzDqmpqWRlZZGfn9+M7+LqFOJipMoq+xCKzcnzvX82AmIioPQCvLyhcevsPAFpydCzg/N1ind0796dxx57jAceeIDY2NgGl7v//vsBOHPmDL/73e947bXXOHHiRJ1lagJ83LhxAKxbt46+fftis9k8Vr8zWsRwSnFxMdnZ2XTt2pXw8HCSk5OZMWMGZWVlPPTQQwQEBPDqq696u0xxwqeH7cMdzoqJgNhI+09n/Okz+xeH+LbY2FjeeOMNjhw5wsyZM68a4JeLj4/n5z//OcePH+f1118nJiYGqB/g5eXlzJw502cCHFpATzw3N5eRI0disViIioqiZ8+enDx5kldeeYUTJ05w5swZAPr27evdQqXRqmyw9WjzbvNsuf3Cof4pzbtdabwRI0awbNkyOnT4zy7ThQsXeOedd9iyZQu7d+/m+PHjVFRUEB4eTvfu3UlPT+e2227je9/7HuHh4QBMnTqV4cOH88gjjzBt2rQ6AT527Fg2b97slffXEL8O8eLiYsaOHYvFYuHJJ5/kueeeIzo6GoCXXnqJ2bNnExwcTEBAAH369PFytdJYBwvtodrc/nFUIe6rHn30URYvXkxgoH1w4dy5c7zwwgssX76ckpKSestbrVb27NnDnj17eP3115kxYwZTp07lmWeeITo6muTkZNavX1/7kAdfDXDw8+GUJ554goKCAh5//HEWLVpUG+AA2dnZpKWlUVlZSUpKSu3uk/i+nK+8s90vv7FfUCS+ZerUqbz22mu1Af7hhx/Sq1cvFi1a5DDAHTl9+jQLFiwgNTWVjz76CKA2wL/99lufDXDw4xA/dOgQq1evpm3btsyfP9/hMunp6QCkpaXVTqsJ/UGDBhEWFuaVxy3J1X192nvbzvfitqW+zMxMlixZUvt6wYIFjBo1isLCQpfaKyoqoqysrM604OBgSktLm1SnJ/ltiK9cuRKbzcakSZMafMRTRIT96NblIX78+HHee+89EhISGDhwYLPUKo13vsI7Qyk18s94b9tSV0REBG+88UZtD/zXv/41Tz31lMvtXXkQ89Il+wUCQUFBvPHGG4SGhja9aA/w2xCv2fXJyspqcJmCggKgbojfeuutFBUV8cEHHzB06FDPFilOs5z18vbPeXf78h9z586le/fuAGzfvp3s7GyX23J0Fsro0aPZvXs3AKmpqfziF79oetEe4LcHNr/++msAOnXq5HB+ZWUl27ZtA+qGeM23ujsNGDAAi8Xi9nZbosQeQ7nlgTcdzqs5B/xqYsL/8/P5CQ0v19B55B9v+Sdzf3hP44r1IRMenElUqxiKLEUkJSXVe+2LrnYaX+vWrZk+fToAFRUVPPjggy6f9ucowGvGwC0WCzk5OYSGhvLEE0/w4osv1htuqdGtW7cm5UdCQgI5Oc5fvea3IV7zF33hwgWH81evXk1xcTHR0dF07tzZo7VYLBaXx+ikrtB2xQ3OqzkHvDECAxu/7OW+ragw8t/SVlVV+7OwsLDea9NMmTKFyEj7P+CyZcs4cuSIS+1cLcAB9u/fz1tvvcXUqVOJiYlh0qRJLF261GFbRUVFLtXQVH4b4gkJCZSUlLBnzx4yMjLqzCsqKmLWrFkA9OnTx+MHL33xfgumah3dcFe71PH3dR0x4fYAt9nsD4Zwtq2ggKo65yGbIjAoqPZnhw4d6r32RTabrcFgfPjhh2t/X7x4sUvtXyvAL29/6tSptdttKMQTExOb3BN3hd+G+NChQzl06BALFixg2LBhtWNnu3bt4v7776e42N6ja46LfFzZRRLHrBXw3+85nteYy+ifn2DvgZdWwPN/dn779989jD/9qsD5Fb1s3v/8kVJrGYkJiRQUFNR77YvKysocnpQQFxdHamoqADt37uTQoUNOt93YAAfYu3cv+/btIy0tjf79+xMVFeVwSOXYsWNERUU5XUtT+e2BzezsbNq0aUN+fj69evWid+/edOvWjUGDBtGlSxeGDBkC1B0PF9/XKty1YRB3SW7jvW2LXf/+/Wt/37Fjh9PrOxPgV24nMDDQ567u9tsQT0pKYuvWrYwePZrw8HDy8vKIj49nyZIlrFu3jqNH7ddtK8TN06mt97bdMd572xa7fv361f5ec/ZIY7kS4Fdu5/IvEV/gt8MpAD169GDt2rX1plutVvLy8ggMDKzdLRNzDOxsf/JOc7vhOoh3fMmBNKP4+P98kzpzS1hXA/zK7cTFxTlRref5dYg35IsvvqC6upru3bvXHuG+3LvvvgvAwYMH67xOSUlhwIABzVeoONSzPcRFQkkzX/QzuHvzbk8cW7p0KZs2bSIiIoLPP/+80eulpaUxfPhwwPl7oeTk5DBy5EgqKir48ssvXarbU1pkiO/fvx9oeChl4sSJDl9PmTKFN99806O1ybUFBsKtN3nuiT6OxEVCn+Tm2540LC8vj7y8PKfXy8nJYfz48axYsYKJEyc6dS+U4uJiNmxo5A3om5lC3IHqaiefNCDN7tYbYXee/ek+zeHemyHIb48gtRwbN24kJSWF8+fPe7sUt2mRH8trhbj4vqBA+IELwVp6wX7vlcacU14joyvclOjcdsR3+VOAQwvtifvqLSXFOe3j4O6BsHpn49dp7CPZaiTHwzjfOhlBpI4W2RMX/5HRFSake6btpDh4NAvCQzzTvog7tMieuPiX226CqDB45zP4ttI9baYmwaQMiPDNu4+K1FKIi18Y0Nl+HveqHXCkCTeMjAyFuwZAegroeSBiAoW4+I24KJg2BL4otD8P87ATN5VrHQGZ3ex/osM9V6OIuynExa8EBNiHQlKT4JvzsD/f/jSegjNQbIWas0cjQu1j3knx9h58j/Y6hVDMpBAXv9UuGob0rDutymYP+kANlYifUIhLi6LetvgbfaRFRAymEBcRMZhCXETEYApxERGD6cCmiPikyMhIrFarW9pauGQVpWXlxERFMuvR+xqc1hSOnk3QHBTiIuKTAgIC3Pbg4dCwcEIvVREaFl7bpqNpJtJwioiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4iLiBhMIS4iYjCFuIiIwRTiIiIGU4j7gIULF5KRkUFcXByxsbEMHjyYDRs2eLsskatav349ffv2JSwsjJSUFF5++WVvl9SstmzZwrhx4+jUqRMBAQG88MILXqlDIe4DNm/ezI9+9CM+/vhjPvvsMzIzMxkzZgzbtm3zdmkiDuXk5DBu3DhGjhxJbm4uzz//PHPmzOG1117zdmnNxmq10rNnT1566SUSEhK8Vkew17YstT788MM6r1966SU2bNjAmjVruOWWW7xUlUjDXn75ZQYOHMj8+fMB6NGjB1988QUvvvgi06ZN83J1zWPUqFGMGjUKgNmzZ3utDoW4D7LZbJSWlhIVFeXtUsQw3168xNeFp+pNr6yqqv159KuCeq8vd33bOFpHX/2zt23bNh566KE600aMGMGiRYsoKCggKSmpKW+jSf5VeIqKi5fqTHP0fhv6O4gICyW5/XXNVG3TKcR90Lx58zh79iyPPPKIt0sRw4SEBLP1s30cyyt0OL/8QgW/+9P6Bl/HxrRi5o/uvuZ2ioqK6g0h1LwuKiryaoifOXeeVX/d7HDele/X0bQfjh9GskcrdC+NifuYxYsXM2/ePN59912v/kcQMwUGBHD3qNuJCA9zaf2Jo24nPCzUzVU1r749u9Lnpi4urds/tTupN3Z2c0WepRD3IYsWLWLWrFl88MEHDB061NvliKFaR0cxfpjzx1IGD+zNDZ3aN2rZxMRELBZLnWmnTp2qnedt4+8YTEyrSKfWiY1pxZ1DMz1UkecoxH3Es88+y9y5c1m/fr0CXJosrWdX0nrc0Ojlr28bx/BbBzZ6+VtuuYWNGzfWmbZhwwY6derkE3uQkRHh3D3q9kYvHwDcM9rMvRCFuA+YOXMmCxcu5O233+bGG2/EYrFgsVg4d+6ct0sTg427YzAxra59cDwoMJB7xmQREtz4Q2Q//elP+eyzz3jmmWc4fPgwv//97/nNb37DU0891ZSS3ap75yQy+vdq1LKDB/ahS8fG7YXUsFqt5Obmkpuby8WLF7FYLOTm5nL8+HFXynVZQHV1dXWzblHqCQgIcDh9ypQpvPnmm81bjPiVY18VsPyKA3lXGn7rQLIy+jnd9rp165gzZw6HDx8mISGBGTNm8LOf/czVUj3i4qVKfvPme3xzpuEO0fVt43h8ygSnvsQAPvnkE7KysupNv+222/jkk0+cLdVlCnHDfJVfRFJCO0JCdGKRNM4HH23jn7u/cDivU4frefQHYwkM9N+d8vyi/+W3b/8Fm4OoCwoMZPqUCbS/ro0XKnMP//2X80PnreUs/9N6Xlq6inOlVm+XI4YYcdt/0S4+tt700JBg7hmd5dcBDpCceB1DMvs7nDfsOwOMDnBQiBvl0537qKysIi4mmphrXIwhUiM0JJh7x2QRGFh32G7MdzNpExfjpaqaV1ZGP5IT29WZlpKUwK2D+nipIvdRiF+mqqqKt99+mzvuuIN27doRFhZGx44dGTFiBMuWLaPq31d4ecN5azk7cg8CMHRweoPj6CKOJCW247uZ6bWve3TtyMA+N3qxouYVFFRz8DYIgNDQECaOvt0v9kLMfwduUlpayrBhw5g8eTJ/+9vfCA0NJS0tDZvNxqZNm3j44Yc5f/681+qr6YV3bH893VI6eK0OMdftGX1JTryOqIhw7hpxa4vrCLSLj2VU1s0AjB2SQZtY/9gL0YHNf5s4cWLtVZJvvfVWnaPOp06dYvny5cyYMcOl+5n85vdrOG+94HJt1dXVnC8rB+znvwYHBbnclrRsVTYbNpvN6TMx/EV1dTUXL1USGhLsc19i0a0i+MmUu5xeTyEO7N69mwEDBhAcHMzevXtJTU11a/vz/uePlFrL3NqmiPiXmFZRzJk+yen1WubX8RXef/99AEaPHu32AAf7N6yr1AsXaRlczQmFOHDwoP2AYUZGhkfad2UXqcbav2/nHzn76dj+eh774Z0+twsoIt6lEMd+UBOgdevWHmnf1THxy3vhxSXnmL94hbtLExEf4eqYuEIciImxH6X21L1KzlsvNHlMvPxChZuqERF/ohAHevXqxZo1a9i+fbtH2ndlrEtj4SIti6tj4jo7Bdi7dy/9+/cnJCSE3Nxcevbs6e2SNBYuIo2ii32Afv36cc8993Dp0iVGjhzJp59+Wmf+qVOnmD9/PmVlzXOaoK7OFJHGUk/830pLSxk3blztLSQ7dOhA+/btKSoqorCwkOrqakpKSoiNjfV4LeqFi0hjqSf+bzExMXz00UcsX76c22+/nfLycvbt20dgYCDDhw9n+fLlREdHN0straIiCA8LVS9cRK5JPXEfVfHtRcJCQxTiInJVCnEREYNpOEVExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQMphAXETGYQlxExGAKcRERgynERUQM9n8wwEoOGPYewwAAAABJRU5ErkJggg==",
+                        "text/plain": [
+                            "<Figure size 454.517x284.278 with 1 Axes>"
+                        ]
+                    },
+                    "execution_count": 12,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
+                "job_id = job.job_id()  # Here we use the job ID from above, but this can be any old job ID\n",
+                "job_old = backend.retrieve_job(job_id)\n",
+                "job_old.input_circuits(index=0).draw(output=\"mpl\")"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.16"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -134,7 +134,6 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
         """Lists the backends available from this provider.
 
         Args:
-            Args:
             simulator: Optional flag to restrict the list of targets to (non-) simulators.
             supports_submit: Optional boolean flag to only return targets that (don't) allow
                 circuit submissions.

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -78,7 +78,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
             api_version: The version of the API.
             max_retry_seconds: The number of seconds to retry calls for. Defaults to one hour.
             verbose: Whether to print to stdio and stderr on retriable errors.
-            cq_token: Token from CQ cloud.This is required to submit circuits to CQ hardware.
+            cq_token: Token from CQ cloud. This is required to submit circuits to CQ hardware.
             ibmq_token: Your IBM Quantum or IBM Cloud token. This is required to submit circuits
                 to IBM hardware, or to access non-public IBM devices you may have access to.
             ibmq_instance: An optional instance to use when running IBM jobs.
@@ -125,6 +125,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
         self,
         simulator: bool | None = None,
         supports_submit: bool | None = None,
+        supports_submit_qubo: bool | None = None,
         supports_compile: bool | None = None,
         available: bool | None = None,
         retired: bool | None = None,
@@ -133,9 +134,12 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
         """Lists the backends available from this provider.
 
         Args:
+            Args:
             simulator: Optional flag to restrict the list of targets to (non-) simulators.
             supports_submit: Optional boolean flag to only return targets that (don't) allow
                 circuit submissions.
+            supports_submit_qubo: Optional boolean flag to only return targets that (don't)
+                allow qubo submissions.
             supports_compile: Optional boolean flag to return targets that (don't) support
                 circuit compilation.
             available: Optional boolean flag to only return targets that are (not) available
@@ -149,7 +153,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
         filters = dict(
             simulator=simulator,
             supports_submit=supports_submit,
-            supports_submit_qubo=False,
+            supports_submit_qubo=supports_submit_qubo,
             supports_compile=supports_compile,
             available=available,
             retired=retired,
@@ -364,7 +368,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
             error_rates: Optional dictionary assigning relative error rates to pairs of physical
                 qubits, in the form `{<qubit_indices>: <error_rate>, ...}` where `<qubit_indices>`
                 is a tuple physical qubit indices (ints) and `<error_rate>` is a relative error rate
-                for gates acting on those qubits (for example `{(0, 1): 0.3, (1, 2): 0.2}`) . If
+                for gates acting on those qubits (for example `{(0, 1): 0.3, (1, 2): 0.2}`). If
                 provided, Superstaq will attempt to map the circuit to minimize the total error on
                 each qubit.
             kwargs: Other desired qscout_compile options.
@@ -460,7 +464,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
         shots: int,
         **kwargs: Any,
     ) -> list[str]:
-        """Executes the circuits neccessary for the DFE protocol.
+        """Executes the circuits necessary for the DFE protocol.
 
         The circuits used to prepare the desired states should not contain final measurements, but
         can contain mid-circuit measurements (as long as the intended target supports them). For
@@ -540,7 +544,7 @@ class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
 
         Raises:
             ValueError: If `ids` is not of size two.
-            SuperstaqServerException: If there was an error accesing the API or the jobs submitted
+            SuperstaqServerException: If there was an error accessing the API or the jobs submitted
                 through `submit_dfe` have not finished running.
         """
         return self._client.process_dfe(ids)


### PR DESCRIPTION
Fixes an issue with `ss_unconstrained_simulator` being excluded from a `qiskit_superstaq.SuperstaqProvider().backends()` call after recent updates such as https://github.com/Infleqtion/client-superstaq/pull/914.