### PR TITLE
Temp skip of `test_ibmq_compile_with_token()`

### DIFF
--- a/.github/integration-check-failure-issue.md
+++ b/.github/integration-check-failure-issue.md
@@ -1,3 +1,4 @@
 ---
 title: Integration test failed
+labels: reminder
 ---

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
+
 from __future__ import annotations
 
 import os
@@ -35,6 +36,9 @@ def test_ibmq_compile(service: css.Service) -> None:
     assert out.pulse_sequence is not None
 
 
+@pytest.mark.skip(
+    reason="Consistently failing due to https://github.com/Qiskit/qiskit-ibm-runtime/issues/1518."
+)
 def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
     qubits = cirq.LineQubit.range(4)

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 """Integration checks that run daily (via Github action) between client and prod server."""
+
 from __future__ import annotations
 
 import os
@@ -49,6 +50,9 @@ def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
     assert isinstance(out.pulse_sequence, qiskit.pulse.Schedule)
 
 
+@pytest.mark.skip(
+    reason="Consistently failing due to https://github.com/Qiskit/qiskit-ibm-runtime/issues/1518."
+)
 def test_ibmq_compile_with_token() -> None:
     provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
     qc = qiskit.QuantumCircuit(4)


### PR DESCRIPTION
Due to `test_ibmq_compile_with_token()` consistently failing the daily integration tests, this PR adds a `pytest.mark.skip` temporarily till the underlying issue is resolved. 

(Also adds a label to be added for the bot)