### PR TITLE
speed up mermin bell benchmark

### DIFF
--- a/supermarq-benchmarks/supermarq/benchmarks/hamiltonian_simulation.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/hamiltonian_simulation.py
@@ -133,7 +133,7 @@ class HamiltonianSimulation(Benchmark):
 
         return circuit
 
-    def _average_magnetization(self, result: Mapping[str, float], shots: int) -> float:
+    def _average_magnetization(self, result: Mapping[str, float], shots: float) -> float:
         mag = 0.0
         for spin_str, count in result.items():
             spin_int = [1 - 2 * int(s) for s in spin_str]
@@ -157,7 +157,7 @@ class HamiltonianSimulation(Benchmark):
         """
         ideal_counts = supermarq.simulation.get_ideal_counts(self.circuit())
 
-        total_shots = int(sum(counts.values()))
+        total_shots = sum(counts.values())
 
         mag_ideal = self._average_magnetization(ideal_counts, 1)
         mag_experimental = self._average_magnetization(counts, total_shots)

--- a/supermarq-benchmarks/supermarq/benchmarks/mermin_bell.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/mermin_bell.py
@@ -174,10 +174,9 @@ class MerminBell(Benchmark):
         for num_y in range(1, num_qubits + 1, 2):
             coef = (-1.0) ** (num_y // 2)
 
-            for y_indices in itertools.combinations(range(num_qubits), num_y):
-                pauli = ["X"] * num_qubits
-                for i in y_indices:
-                    pauli[i] = "Y"
+            for x_indices in itertools.combinations(range(num_qubits), num_qubits - num_y):
+                pauli = np.array(["Y"] * num_qubits)
+                pauli.put(x_indices, "X")
                 mermin_op.append((coef, "".join(pauli)))
 
         return mermin_op

--- a/supermarq-benchmarks/supermarq/benchmarks/mermin_bell.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/mermin_bell.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import itertools
 from typing import cast
 
 import cirq
 import numpy as np
-import sympy
 
 from supermarq import stabilizers
 from supermarq.benchmark import Benchmark
@@ -170,31 +170,15 @@ class MerminBell(Benchmark):
         (https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.65.1838), or M_n
         (Eq. 2.8) in https://arxiv.org/pdf/2005.11271.pdf
         """
-        x = sympy.symbols(f"x_1:{num_qubits + 1}")
-        y = sympy.symbols(f"y_1:{num_qubits + 1}")
-
-        term1 = 1
-        term2 = 1
-        for j in range(num_qubits):
-            term1 = term1 * (x[j] + sympy.I * y[j])
-            term2 = term2 * (x[j] - sympy.I * y[j])
-        term1 = sympy.expand(term1)
-        term2 = sympy.expand(term2)
-
-        M_n = (1 / (2 * sympy.I)) * (term1 - term2)
-        M_n = sympy.simplify(M_n)
-
-        variables = M_n.as_terms()[1]
         mermin_op = []
-        for term in M_n.as_terms()[0]:
-            coef = term[1][0][0]
-            pauli = [""] * num_qubits
-            for i, v in enumerate(term[1][1]):
-                if v == 1:
-                    char, idx = str(variables[i]).split("_")
-                    pauli[int(idx) - 1] = char.upper()
+        for num_y in range(1, num_qubits + 1, 2):
+            coef = (-1.0) ** (num_y // 2)
 
-            mermin_op.append((coef, "".join(pauli)))
+            for y_indices in itertools.combinations(range(num_qubits), num_y):
+                pauli = ["X"] * num_qubits
+                for i in y_indices:
+                    pauli[i] = "Y"
+                mermin_op.append((coef, "".join(pauli)))
 
         return mermin_op
 


### PR DESCRIPTION
significantly speeds up the mermin bell constructor by removing the expensive sympy logic in `_mermin_operator` (instead we can just iterate over every pauli string with an odd number of Ys, with eigenvalues `(-1)**((num_ys-1)/2)`) (something similar is described in https://arxiv.org/pdf/2005.11271)

constructor times before:
```
MerminBell(8):  0.553s
MerminBell(10): 2.998s
MerminBell(12): 18.75s
MerminBell(14): 82.12s
```
after:
```
MerminBell(8):  0.001s
MerminBell(10): 0.003s
MerminBell(12): 0.010s
MerminBell(14): 0.043s
...
MerminBell(18): 0.815s
MerminBell(20): 4.515s
```