### PR TITLE
adding back in module info for clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,9 +79,6 @@ autoapi
 _build_rtd
 docs/source/modules.rst
 docs/source/setup.rst
-docs/source/general_superstaq.rst
-docs/source/cirq_superstaq.rst
-docs/source/qiskit_superstaq.rst
 docs/_build/
 
 # PyBuilder

--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,11 @@ _build
 _readthedocs_build
 autoapi
 _build_rtd
+docs/source/cirq_superstaq.ops.rst
+docs/source/general_superstaq.check.rst
 docs/source/modules.rst
 docs/source/setup.rst
+docs/source/supermarq.benchmarks.rst
 docs/_build/
 
 # PyBuilder

--- a/docs/source/cirq_superstaq.rst
+++ b/docs/source/cirq_superstaq.rst
@@ -1,0 +1,69 @@
+cirq\_superstaq package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   cirq_superstaq.ops
+
+Submodules
+----------
+
+cirq\_superstaq.compiler\_output module
+---------------------------------------
+
+.. automodule:: cirq_superstaq.compiler_output
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cirq\_superstaq.job module
+--------------------------
+
+.. automodule:: cirq_superstaq.job
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cirq\_superstaq.sampler module
+------------------------------
+
+.. automodule:: cirq_superstaq.sampler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cirq\_superstaq.serialization module
+------------------------------------
+
+.. automodule:: cirq_superstaq.serialization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cirq\_superstaq.service module
+------------------------------
+
+.. automodule:: cirq_superstaq.service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cirq\_superstaq.validation module
+---------------------------------
+
+.. automodule:: cirq_superstaq.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: cirq_superstaq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/general_superstaq.rst
+++ b/docs/source/general_superstaq.rst
@@ -1,0 +1,85 @@
+general\_superstaq package
+==========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   general_superstaq.check
+
+Submodules
+----------
+
+general\_superstaq.resource\_estimate module
+--------------------------------------------
+
+.. automodule:: general_superstaq.resource_estimate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.serialization module
+---------------------------------------
+
+.. automodule:: general_superstaq.serialization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.service module
+---------------------------------
+
+.. automodule:: general_superstaq.service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.superstaq\_client module
+-------------------------------------------
+
+.. automodule:: general_superstaq.superstaq_client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.superstaq\_exceptions module
+-----------------------------------------------
+
+.. automodule:: general_superstaq.superstaq_exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.testing module
+---------------------------------
+
+.. automodule:: general_superstaq.testing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.typing module
+--------------------------------
+
+.. automodule:: general_superstaq.typing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+general\_superstaq.validation module
+------------------------------------
+
+.. automodule:: general_superstaq.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: general_superstaq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,8 +75,9 @@ Learn more about Superstaq `here <https://www.infleqtion.com/superstaq>`_. To co
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Clients
+   :caption: API Guide
 
    cirq_superstaq
    qiskit_superstaq
    general_superstaq
+   supermarq

--- a/docs/source/qiskit_superstaq.rst
+++ b/docs/source/qiskit_superstaq.rst
@@ -1,0 +1,77 @@
+qiskit\_superstaq package
+=========================
+
+Submodules
+----------
+
+qiskit\_superstaq.compiler\_output module
+-----------------------------------------
+
+.. automodule:: qiskit_superstaq.compiler_output
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.conftest module
+---------------------------------
+
+.. automodule:: qiskit_superstaq.conftest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.custom\_gates module
+--------------------------------------
+
+.. automodule:: qiskit_superstaq.custom_gates
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.serialization module
+--------------------------------------
+
+.. automodule:: qiskit_superstaq.serialization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.superstaq\_backend module
+-------------------------------------------
+
+.. automodule:: qiskit_superstaq.superstaq_backend
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.superstaq\_job module
+---------------------------------------
+
+.. automodule:: qiskit_superstaq.superstaq_job
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.superstaq\_provider module
+--------------------------------------------
+
+.. automodule:: qiskit_superstaq.superstaq_provider
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+qiskit\_superstaq.validation module
+-----------------------------------
+
+.. automodule:: qiskit_superstaq.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: qiskit_superstaq
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/supermarq.rst
+++ b/docs/source/supermarq.rst
@@ -1,0 +1,77 @@
+supermarq package
+=================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   supermarq.benchmarks
+
+Submodules
+----------
+
+supermarq.benchmark module
+--------------------------
+
+.. automodule:: supermarq.benchmark
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.converters module
+---------------------------
+
+.. automodule:: supermarq.converters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.features module
+-------------------------
+
+.. automodule:: supermarq.features
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.plotting module
+-------------------------
+
+.. automodule:: supermarq.plotting
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.run\_benchmarks module
+--------------------------------
+
+.. automodule:: supermarq.run_benchmarks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.simulation module
+---------------------------
+
+.. automodule:: supermarq.simulation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+supermarq.stabilizers module
+----------------------------
+
+.. automodule:: supermarq.stabilizers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: supermarq
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Adding API module info back into docs (noting that this brings up the old warnings when you build docs)