### PR TITLE
add `method=` argument to GHZ benchmark

### DIFF
--- a/supermarq-benchmarks/supermarq/benchmarks/ghz.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/ghz.py
@@ -21,15 +21,15 @@ class GHZ(Benchmark):
 
         Args:
             num_qubits: Number of qubits in GHZ circuit.
-            method: Circuit construction method to use. Must be "ladder", "star", or "fanout". The
+            method: Circuit construction method to use. Must be "ladder", "star", or "logdepth". The
                 "ladder" method uses a linear-depth CNOT ladder, appropriate for nearest-neighbor
                 architectures. The "star" method is also linear depth, but with all CNOTs sharing
-                the same control qubit. The "fanout" method uses a log-depth CNOT fanout.
+                the same control qubit. The "logdepth" method uses a log-depth CNOT fanout circuit.
         """
-        if method not in ("ladder", "star", "fanout"):
+        if method not in ("ladder", "star", "logdepth"):
             raise ValueError(
                 f"'{method}' is not a valid GHZ circuit construction method. Valid options are "
-                "'ladder', 'star', and 'fanout'."
+                "'ladder', 'star', and 'logdepth'."
             )
         self.num_qubits = num_qubits
         self.method = method

--- a/supermarq-benchmarks/supermarq/benchmarks/ghz_test.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/ghz_test.py
@@ -7,7 +7,7 @@ import qiskit.quantum_info
 from supermarq.benchmarks.ghz import GHZ
 
 
-@pytest.mark.parametrize("method", ["ladder", "star", "fanout"])
+@pytest.mark.parametrize("method", ["ladder", "star", "logdepth"])
 @pytest.mark.parametrize("num_qubits", [3, 4, 7])
 def test_ghz_circuit(method: str, num_qubits: int) -> None:
     ghz = GHZ(num_qubits, method=method)
@@ -39,8 +39,8 @@ def test_ghz_circuit(method: str, num_qubits: int) -> None:
 def test_ghz_circuit_methods() -> None:
     star = GHZ(8, method="star").circuit()
     ladder = GHZ(8, method="ladder").circuit()
-    fanout = GHZ(8, method="fanout").circuit()
-    assert len(fanout) < len(ladder) == len(star)
+    logdepth = GHZ(8, method="logdepth").circuit()
+    assert len(logdepth) < len(ladder) == len(star)
 
 
 def test_ghz_invalid_method() -> None:

--- a/supermarq-benchmarks/supermarq/benchmarks/ghz_test.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/ghz_test.py
@@ -1,15 +1,51 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 import cirq
+import numpy as np
+import pytest
+import qiskit.quantum_info
 
 from supermarq.benchmarks.ghz import GHZ
 
 
-def test_ghz_circuit() -> None:
-    ghz = GHZ(3)
-    cirq_circuit = ghz.cirq_circuit()
-    if isinstance(cirq_circuit, cirq.Circuit):
-        assert len(cirq_circuit.all_qubits()) == 3
-    assert ghz.qiskit_circuit().num_qubits == 3
+@pytest.mark.parametrize("method", ["ladder", "star", "fanout"])
+@pytest.mark.parametrize("num_qubits", [3, 4, 7])
+def test_ghz_circuit(method: str, num_qubits: int) -> None:
+    ghz = GHZ(num_qubits, method=method)
+
+    cirq_circuit = ghz.circuit()
+    assert cirq_circuit == ghz.cirq_circuit()
+
+    assert cirq.num_qubits(cirq_circuit) == num_qubits
+    expected_state_vector = np.zeros(2**num_qubits)
+    expected_state_vector[0] = expected_state_vector[-1] = np.sqrt(0.5)
+
+    cirq.testing.assert_allclose_up_to_global_phase(
+        cirq_circuit.final_state_vector(ignore_terminal_measurements=True),
+        expected_state_vector,
+        atol=1e-8,
+    )
+
+    qiskit_circuit = ghz.qiskit_circuit()
+    assert qiskit_circuit.num_qubits == num_qubits
+
+    qiskit_circuit.remove_final_measurements()
+    cirq.testing.assert_allclose_up_to_global_phase(
+        qiskit.quantum_info.Statevector(qiskit_circuit).data,
+        expected_state_vector,
+        atol=1e-8,
+    )
+
+
+def test_ghz_circuit_methods() -> None:
+    star = GHZ(8, method="star").circuit()
+    ladder = GHZ(8, method="ladder").circuit()
+    fanout = GHZ(8, method="fanout").circuit()
+    assert len(fanout) < len(ladder) == len(star)
+
+
+def test_ghz_invalid_method() -> None:
+    with pytest.raises(ValueError, match="'foo' is not a valid"):
+        _ = GHZ(3, method="foo")
 
 
 def test_ghz_score() -> None:


### PR DESCRIPTION
allows selection between a "ladder" circuit (the current implementation), "star" (the typical GHZ structure, with all CNOTs sharing the same control), and "fanout" (using a log-depth fanout circuit)