### PR TITLE
add benchmark classes to `benchmarks.__init__`

### DIFF
--- a/supermarq-benchmarks/supermarq/benchmarks/__init__.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/__init__.py
@@ -1,0 +1,37 @@
+from . import (
+    bit_code,
+    ghz,
+    hamiltonian_simulation,
+    mermin_bell,
+    phase_code,
+    qaoa_fermionic_swap_proxy,
+    qaoa_vanilla_proxy,
+    vqe_proxy,
+)
+from .bit_code import BitCode
+from .ghz import GHZ
+from .hamiltonian_simulation import HamiltonianSimulation
+from .mermin_bell import MerminBell
+from .phase_code import PhaseCode
+from .qaoa_fermionic_swap_proxy import QAOAFermionicSwapProxy
+from .qaoa_vanilla_proxy import QAOAVanillaProxy
+from .vqe_proxy import VQEProxy
+
+__all__ = [
+    "BitCode",
+    "GHZ",
+    "HamiltonianSimulation",
+    "MerminBell",
+    "PhaseCode",
+    "QAOAFermionicSwapProxy",
+    "QAOAVanillaProxy",
+    "VQEProxy",
+    "bit_code",
+    "ghz",
+    "hamiltonian_simulation",
+    "mermin_bell",
+    "phase_code",
+    "qaoa_fermionic_swap_proxy",
+    "qaoa_vanilla_proxy",
+    "vqe_proxy",
+]


### PR DESCRIPTION
so we can use e.g. `supermarq.benchmarks.HamiltonianSimulation` instead of `supermarq.benchmarks.hamiltonian_simulation.HamiltonianSimulation`