### PR TITLE
Store `AceCR` properties in `self.params`

### DIFF
--- a/qiskit-superstaq/qiskit_superstaq/custom_gates.py
+++ b/qiskit-superstaq/qiskit_superstaq/custom_gates.py
@@ -45,8 +45,6 @@ class AceCR(qiskit.circuit.Gate):
             params.append(sandwich_rx_rads)
         super().__init__(name, 2, params, label=label)
 
-        self.params = params
-
     def inverse(self) -> AceCR:
         """Inverts the AceCR gate.
 


### PR DESCRIPTION
Fixes #953 compilation error:
```python
import qiskit_superstaq as qss
provider = qss.SuperstaqProvider()
brisbane = provider.get_backend("ibmq_brisbane_qpu")

theta = qiskit.circuit.Parameter("θ")
qc = qiskit.QuantumCircuit(2, 2)
qc.append(qss.AceCR(theta), (0, 1))
qc.measure((0, 1), (0, 1))
#      ┌───────────┐┌─┐   
# q_0: ┤0          ├┤M├───
#      │  Acecr(θ) │└╥┘┌─┐
# q_1: ┤1          ├─╫─┤M├
#      └───────────┘ ║ └╥┘
# c: 2/══════════════╩══╩═
#                    0  1 

qc_bound = qc.assign_parameters({theta: np.pi / 3})
#      ┌─────────────┐┌─┐   
# q_0: ┤0            ├┤M├───
#      │  Acecr(π/3) │└╥┘┌─┐
# q_1: ┤1            ├─╫─┤M├
#      └─────────────┘ ║ └╥┘
# c: 2/════════════════╩══╩═
#                      0  1 
brisbane.compile(qc_bound)
# In `main`:
#     SuperstaqServerException: Can't convert parameterized unbounded qiskit circuits. Please let us know if you'd like this feature  
#     (Status code: 400, non-retriable error making request to Superstaq API)
# In `compile-bound`: No exception raised.
```