### PR TITLE
remove qiskit.providers.Provider inheritence

### DIFF
--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from _typeshed import SupportsItems
 
 
-class SuperstaqProvider(qiskit.providers.ProviderV1, gss.service.Service):
+class SuperstaqProvider(gss.service.Service):
     """Provider for Superstaq backend.
 
     Typical usage is:


### PR DESCRIPTION
`qiskit.providers.Provider` [has been deprecated](https://github.com/Qiskit/qiskit/blob/473c3c2e58f855332532c2c47a11db5695c0180f/qiskit/providers/provider.py#L47-L52). we don't inherit anything from it anyway.