### PR TITLE
Remove prefix hardcoding in `validate_target()`

### DIFF
--- a/general-superstaq/general_superstaq/validation.py
+++ b/general-superstaq/general_superstaq/validation.py
@@ -48,6 +48,7 @@ def validate_target(target: str) -> None:
         "rigetti",
         "qscout",
         "ss",
+        "iqm",
         "toshiba",
     ]
 

--- a/general-superstaq/general_superstaq/validation.py
+++ b/general-superstaq/general_superstaq/validation.py
@@ -28,30 +28,14 @@ def validate_integer_param(integer_param: object, min_val: int = 1) -> None:
 
 
 def validate_target(target: str) -> None:
-    """Checks that a target contains a valid format, vendor prefix, and device type.
+    """Checks that `target` conforms to a valid Superstaq format and device type.
 
     Args:
         target: A string containing the name of a target device.
 
     Raises:
-        ValueError: If `target` has an invalid format, vendor prefix, or device type.
+        ValueError: If `target` has an invalid format or device type.
     """
-    vendor_prefixes = [
-        "aqt",
-        "aws",
-        "cq",
-        "qtm",
-        "ibmq",
-        "ionq",
-        "oxford",
-        "quera",
-        "rigetti",
-        "qscout",
-        "ss",
-        "iqm",
-        "toshiba",
-    ]
-
     target_device_types = ["qpu", "simulator"]
 
     # Check valid format
@@ -62,14 +46,7 @@ def validate_target(target: str) -> None:
             "the form '<provider>_<device>_<type>', e.g. 'ibmq_brisbane_qpu'."
         )
 
-    prefix, _, device_type = match.groups()
-
-    # Check valid prefix
-    if prefix not in vendor_prefixes:
-        raise ValueError(
-            f"{target!r} does not have a valid target prefix. Valid prefixes are: "
-            f"{vendor_prefixes}."
-        )
+    _, _, device_type = match.groups()
 
     # Check for valid device type
     if device_type not in target_device_types:

--- a/general-superstaq/general_superstaq/validation_test.py
+++ b/general-superstaq/general_superstaq/validation_test.py
@@ -16,9 +16,6 @@ def test_validate_target() -> None:
     with pytest.raises(ValueError, match="does not have a valid target device type"):
         gss.validation.validate_target("ibmq_invalid_device")
 
-    with pytest.raises(ValueError, match="does not have a valid target prefix"):
-        gss.validation.validate_target("invalid_test_qpu")
-
 
 def test_validate_integer_param() -> None:
     # Tests for valid inputs -> Pass


### PR DESCRIPTION
Addresses part of https://github.com/Infleqtion/client-superstaq/issues/958 by unblocking the `backends()` endpoint of `qiskit-superstaq`. 

Will also allow calls to the `compile` endpoint with `iqm_*` backends (though further optimization may be needed).
 
