### PR TITLE
Disable socket

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -1,5 +1,13 @@
 # Check script configuration:
 
+[tool.pytest.ini_options]
+addopts = "--disable-socket"
+filterwarnings = [
+  "ignore::UserWarning:qtrl.*",
+  "ignore::PendingDeprecationWarning:qtrl.utils.config",
+  "ignore::PendingDeprecationWarning:ruamel.yaml.main",
+]
+
 [tool.black]
 color = true
 line_length = 100

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -38,8 +38,6 @@ def run(
         """
     )
 
-    parser.add_argument("--enable-socket", action="store_true", help="Force-enable socket.")
-
     parsed_args, pytest_args = parser.parse_known_intermixed_args(args)
     if "coverage" in parsed_args.skip:
         return 0
@@ -52,9 +50,6 @@ def run(
     if not test_files:
         print("No test files to check for pytest and coverage.")
         return 0
-
-    if not parsed_args.enable_socket:
-        pytest_args.append("--disable-socket")
 
     coverage_arg = "--include=" + ",".join(files)
     test_returncode = subprocess.call(

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -63,6 +63,7 @@ def run(
     if parsed_args.notebook:
         include = include or "*.ipynb"
     elif parsed_args.integration:
+        args_to_pass += ["--force-enable-socket"]
         include = include or "*_integration_test.py"
     else:
         include = include or "*.py"

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -61,7 +61,6 @@ def run(
     if parsed_args.notebook:
         include = include or "*.ipynb"
     elif parsed_args.integration:
-        args_to_pass += ["--force-enable-socket"]
         include = include or "*_integration_test.py"
     else:
         include = include or "*.py"
@@ -71,7 +70,9 @@ def run(
 
     if parsed_args.notebook:
         args_to_pass += ["--nbmake", "--force-enable-socket"]
-    elif not parsed_args.integration:
+    elif parsed_args.integration:
+        args_to_pass += ["--force-enable-socket"]
+    else:
         files = check_utils.get_test_files(files, exclude=exclude, silent=silent)
 
     if not files:

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -61,6 +61,7 @@ def run(
     if parsed_args.notebook:
         include = include or "*.ipynb"
     elif parsed_args.integration:
+        args_to_pass += ["--force-enable-socket"]
         include = include or "*_integration_test.py"
     else:
         include = include or "*.py"
@@ -71,7 +72,6 @@ def run(
     if parsed_args.notebook:
         args_to_pass += ["--nbmake", "--force-enable-socket"]
     elif not parsed_args.integration:
-        args_to_pass += ["--force-enable-socket"]
         files = check_utils.get_test_files(files, exclude=exclude, silent=silent)
 
     if not files:

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -53,8 +53,6 @@ def run(
         help="Run pytest on *_integration_test.py files.",
     )
 
-    parser.add_argument("--enable-socket", action="store_true", help="Force-enable socket.")
-
     parsed_args, args_to_pass = parser.parse_known_intermixed_args(args)
     if "pytest" in parsed_args.skip:
         return 0
@@ -63,7 +61,6 @@ def run(
     if parsed_args.notebook:
         include = include or "*.ipynb"
     elif parsed_args.integration:
-        args_to_pass += ["--force-enable-socket"]
         include = include or "*_integration_test.py"
     else:
         include = include or "*.py"
@@ -72,12 +69,10 @@ def run(
     files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     if parsed_args.notebook:
-        args_to_pass += ["--nbmake"]
+        args_to_pass += ["--nbmake", "--force-enable-socket"]
     elif not parsed_args.integration:
+        args_to_pass += ["--force-enable-socket"]
         files = check_utils.get_test_files(files, exclude=exclude, silent=silent)
-
-    if not parsed_args.integration and not parsed_args.enable_socket:
-        args_to_pass += ["--disable-socket"]
 
     if not files:
         return 0

--- a/checks-superstaq/requirements.txt
+++ b/checks-superstaq/requirements.txt
@@ -13,6 +13,6 @@ pylint>=2.15.0
 pytest>=6.2.5
 pytest-cov>=2.11.1
 pytest-randomly>=3.10.1
-pytest-socket>=0.4.1
+pytest-socket>=0.7.0
 setuptools>=67.0.0
 sphinx-rtd-theme>=1.0.0


### PR DESCRIPTION
## Adding --disable-socket with updated release of pytest-socket
- Updating the .toml file to include overall disable-socket.
- Updating the pytest_.py and coverage_.py file to use the "--force-enable-socket" flag under notebook and integration statements.

Closes #962 