### PR TITLE
Pylint plugin to check that return type annotation for `__init__` functions is `-> None`

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -63,7 +63,11 @@ include = ["./*"]
 [tool.pylint.main]
 max-line-length = 100
 disable = "all"
-load-plugins = ["pylint.extensions.docparams", "pylint.extensions.docstyle"]
+load-plugins = [
+  "pylint.extensions.docparams", 
+  "pylint.extensions.docstyle", 
+  "checks_superstaq.init_return",
+]
 output-format = "colorized"
 score = false
 reports = false
@@ -82,6 +86,7 @@ enable = [
   "expression-not-assigned",
   "function-redefined",
   "inconsistent-mro",
+  "init-return-check",
   "init-is-generator",
   "line-too-long",
   "lost-exception",

--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -66,7 +66,7 @@ disable = "all"
 load-plugins = [
   "pylint.extensions.docparams", 
   "pylint.extensions.docstyle", 
-  "checks_superstaq.init_return",
+  "checks_superstaq.pylint_init_return",
 ]
 output-format = "colorized"
 score = false

--- a/checks-superstaq/checks_superstaq/init_return.py
+++ b/checks-superstaq/checks_superstaq/init_return.py
@@ -1,0 +1,53 @@
+"""Check type type annotation of __init__ functions"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from astroid import Const, nodes
+from pylint.checkers import BaseChecker
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+
+class InitChecker(BaseChecker):
+    """Checker for return type annotations for class constructors (__init__).
+
+    * Check that all __init__ functions have the return type annotation '-> None'.
+    """
+
+    name = "init-return-check"
+    msgs = {
+        "W9022": (
+            "Missing -> None return type annotation for __init__ method",
+            "missing-return-type-annotation-init",
+            "Missing type annotation for __init__ causes mypy check inconsistentcies.",
+        ),
+        "W9023": (
+            "Incorrect return type annotation for __init__ method. Expected None but found '%s'",
+            "incorrect-return-type-annotation-init",
+            "__init__ functions should only have return type None.",
+        ),
+    }
+
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
+        """Called for function and method definitions (def).
+        Checks if the return type annotation for __init__ is explicity None or incorrect.
+
+        Args:
+            node: Node for a function or method definition in the AST
+        """
+        if node.name == "__init__":
+            if not node.returns:
+                self.add_message("missing-return-type-annotation-init", node=node)
+            elif not isinstance(node.returns, Const):
+                self.add_message(
+                    "incorrect-return-type-annotation-init",
+                    args=node.returns.as_string(),
+                    node=node,
+                )
+
+
+def register(linter: PyLinter) -> None:
+    linter.register_checker(InitChecker(linter))

--- a/checks-superstaq/checks_superstaq/init_return.py
+++ b/checks-superstaq/checks_superstaq/init_return.py
@@ -50,4 +50,9 @@ class InitChecker(BaseChecker):
 
 
 def register(linter: PyLinter) -> None:
+    """Registers plugin to be accessed by pylint
+
+    Args:
+        linter: The base pylinter which the custom checker will inherit from
+    """
     linter.register_checker(InitChecker(linter))

--- a/checks-superstaq/checks_superstaq/pylint_init_return.py
+++ b/checks-superstaq/checks_superstaq/pylint_init_return.py
@@ -1,4 +1,4 @@
-"""Check return type annotation of __init__ functions"""
+"""Check return type annotation of __init__ functions."""
 
 from __future__ import annotations
 

--- a/checks-superstaq/checks_superstaq/pylint_init_return.py
+++ b/checks-superstaq/checks_superstaq/pylint_init_return.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-
+import sys
 from astroid import Const, nodes
 from pylint.checkers import BaseChecker
-
+from pylint.checkers.utils import only_required_for_messages
+import pylint.lint
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
@@ -19,18 +20,19 @@ class InitChecker(BaseChecker):
 
     name = "init-return-check"
     msgs = {
-        "W9022": (
+        "W6061": (
             "Missing -> None return type annotation for __init__ method",
             "missing-return-type-annotation-init",
             "Missing type annotation for __init__ causes mypy check inconsistentcies.",
         ),
-        "W9023": (
+        "W6062": (
             "Incorrect return type annotation for __init__ method. Expected None but found '%s'",
             "incorrect-return-type-annotation-init",
             "__init__ functions should only have return type None.",
         ),
     }
-
+    
+    @only_required_for_messages("init-return-check")
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Called for function and method definitions (def).
 
@@ -56,4 +58,7 @@ def register(linter: PyLinter) -> None:
     Args:
         linter: The base pylinter which the custom checker will inherit from.
     """
+    x = pylint.lint.PyLinter()
+    for i in x.msgs.keys():
+        sys.stdout.write(i + " ")
     linter.register_checker(InitChecker(linter))

--- a/checks-superstaq/checks_superstaq/pylint_init_return.py
+++ b/checks-superstaq/checks_superstaq/pylint_init_return.py
@@ -1,4 +1,4 @@
-"""Check type type annotation of __init__ functions"""
+"""Check return type annotation of __init__ functions"""
 
 from __future__ import annotations
 
@@ -33,10 +33,11 @@ class InitChecker(BaseChecker):
 
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Called for function and method definitions (def).
+
         Checks if the return type annotation for __init__ is explicity None or incorrect.
 
         Args:
-            node: Node for a function or method definition in the AST
+            node: Node for a function or method definition in the AST.
         """
         if node.name == "__init__":
             if not node.returns:
@@ -50,9 +51,9 @@ class InitChecker(BaseChecker):
 
 
 def register(linter: PyLinter) -> None:
-    """Registers plugin to be accessed by pylint
+    """Registers plugin to be accessed by pylint.
 
     Args:
-        linter: The base pylinter which the custom checker will inherit from
+        linter: The base pylinter which the custom checker will inherit from.
     """
     linter.register_checker(InitChecker(linter))

--- a/checks-superstaq/checks_superstaq/pylint_init_return.py
+++ b/checks-superstaq/checks_superstaq/pylint_init_return.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-import sys
+
 from astroid import Const, nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
-import pylint.lint
+
 if TYPE_CHECKING:
     from pylint.lint import PyLinter
 
@@ -31,7 +31,7 @@ class InitChecker(BaseChecker):
             "__init__ functions should only have return type None.",
         ),
     }
-    
+
     @only_required_for_messages("init-return-check")
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Called for function and method definitions (def).
@@ -58,7 +58,4 @@ def register(linter: PyLinter) -> None:
     Args:
         linter: The base pylinter which the custom checker will inherit from.
     """
-    x = pylint.lint.PyLinter()
-    for i in x.msgs.keys():
-        sys.stdout.write(i + " ")
     linter.register_checker(InitChecker(linter))

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -58,7 +58,7 @@ class _SuperstaqClient:
         ibmq_instance: str | None = None,
         ibmq_channel: str | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         """Creates the SuperstaqClient.
 
         Users should use `$client_superstaq.Service` instead of this class directly.


### PR DESCRIPTION
The return type annotation for `__init__` is inconsistently enforced by `mypy`. The plugin will warn when there is no explicit return type annotation and when the return type in the annotation is not `None`.