### PR TITLE
support both `<x>_test.py` and `test_<x>.py` for test discovery

### DIFF
--- a/checks-superstaq/checks_superstaq/check_utils.py
+++ b/checks-superstaq/checks_superstaq/check_utils.py
@@ -252,7 +252,7 @@ def get_test_files(
 ) -> list[str]:
     """For the given files, identify all associated test files.
 
-    I.e. test files are those with the same name, but with a "_test.py" suffix).
+    I.e. test files are those with the same name, but with a "_test.py" suffix or "test_" prefix.
 
     Args:
         files: The list of files to search for associated test files of.
@@ -265,12 +265,17 @@ def get_test_files(
 
     test_files = []
     for file in files:
-        if file.split("::")[0].endswith("_test.py"):
+        basename = os.path.basename(file).split("::")[0]
+
+        if basename.endswith("_test.py") or basename.startswith("test_"):
             test_files.append(file)
         else:
-            test_file = re.sub(r"\.py$", "_test.py", file)
-            if os.path.isfile(os.path.join(root_dir, test_file)):
+            if os.path.isfile(test_file := re.sub(r"\.py$", "_test.py", file)):
                 test_files.append(test_file)
+
+            elif os.path.isfile(test_file := re.sub(rf"{basename}$", f"test_{basename}", file)):
+                test_files.append(test_file)
+
             elif not silent:
                 print(warning(f"WARNING: no test file found for {file}"))
 

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -73,7 +73,9 @@ def run(
 
     # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in `files`
     # both will be included in the coverage report
-    files.sort(key=lambda file: file.endswith("_test.py"))
+    files.sort(
+        key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
+    )
     coverage_args.append("--append")
     test_returncode = 0
 

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap


### PR DESCRIPTION
some repos use the latter