### PR TITLE
drop qiskit-ibm-provider from qss

### DIFF
--- a/qiskit-superstaq/example-requirements.txt
+++ b/qiskit-superstaq/example-requirements.txt
@@ -1,3 +1,4 @@
 matplotlib>=3.7.0
 notebook>=6.5.5
 pylatexenc>=2.0
+qiskit-ibm-provider>=0.11.0

--- a/qiskit-superstaq/qiskit_superstaq/serialization_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/serialization_test.py
@@ -15,6 +15,14 @@ import qiskit.qasm2
 import qiskit_superstaq as qss
 
 
+def test_qpy_serialization_version() -> None:
+    assert (
+        qiskit.qpy.common.QPY_COMPATIBILITY_VERSION
+        <= qss.serialization.QPY_SERIALIZATION_VERSION
+        <= qiskit.qpy.common.QPY_VERSION
+    )
+
+
 def test_to_json() -> None:
     real_part = np.random.uniform(-1, 1, size=(4, 4))
     imag_part = np.random.uniform(-1, 1, size=(4, 4))
@@ -143,7 +151,7 @@ def test_warning_suppression() -> None:
 
     # QPY encodes qiskit.__version__ into the serialized circuit, so mocking a newer version string
     # during serialization will cause a QPY version UserWarning during deserialization
-    with mock.patch("qiskit_ibm_provider.qpy.interface.__version__", newer_version):
+    with mock.patch("qiskit.qpy.interface.__version__", newer_version):
         serialized_circuit = qss.serialization.serialize_circuits(circuit)
 
     # Check that a warning would normally be thrown
@@ -162,10 +170,11 @@ def test_deserialization_errors() -> None:
     circuit.x(0)
 
     # Mock a circuit serialized with a newer version of QPY:
-    with mock.patch(
-        "qiskit_ibm_provider.qpy.common.QPY_VERSION", qiskit.qpy.common.QPY_VERSION + 1
-    ):
-        serialized_circuit = qss.serialize_circuits(circuit)
+    with mock.patch("qiskit_superstaq.serialization.QPY_SERIALIZATION_VERSION", None):
+        with mock.patch("qiskit.qpy.common.QPY_VERSION", qiskit.qpy.common.QPY_VERSION + 1):
+            print(qss.serialization.QPY_SERIALIZATION_VERSION)
+            print(qiskit.qpy.common.QPY_VERSION)
+            serialized_circuit = qss.serialize_circuits(circuit)
 
     # Remove a few bytes to force a deserialization error
     serialized_circuit = gss.serialization.bytes_to_str(
@@ -173,11 +182,13 @@ def test_deserialization_errors() -> None:
     )
 
     with pytest.raises(ValueError, match="your version of Qiskit"):
-        _ = qss.deserialize_circuits(serialized_circuit)
+        with mock.patch("qiskit.qpy.common.QPY_VERSION", qiskit.qpy.common.QPY_VERSION - 3):
+            _ = qss.deserialize_circuits(serialized_circuit)
 
     # Mock a circuit serialized with an older of QPY:
-    with mock.patch("qiskit_ibm_provider.qpy.common.QPY_VERSION", 3):
-        serialized_circuit = qss.serialize_circuits(circuit)
+    with mock.patch("qiskit_superstaq.serialization.QPY_SERIALIZATION_VERSION", None):
+        with mock.patch("qiskit.qpy.common.QPY_VERSION", 3):
+            serialized_circuit = qss.serialize_circuits(circuit)
 
     with pytest.raises(ValueError, match="Please contact"):
         _ = qss.deserialize_circuits(serialized_circuit)

--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -1,4 +1,3 @@
 general-superstaq~=0.5.19
-qiskit>=0.45.1
-qiskit-ibm-provider>=0.9.0
+qiskit>=1.0.0
 symengine~=0.11.0


### PR DESCRIPTION
qiskit-ibm-provider is deprecated, so this removes it from user-facing code/requirements. We still use it in a few places in the docs; these should also be updated so we can drop it from example-requirements too

requires us to bump our qiskit req to 1.0.0, hopefully this has been around long enough that it isn't an issue for anyone