### PR TITLE
allow overriding number of pytest threads

### DIFF
--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -86,7 +86,7 @@ def run(
         integration_setup()
 
     return subprocess.call(
-        ["python", "-m", "pytest", *files, *args_to_pass, "-n=auto"],
+        ["python", "-m", "pytest", "-n=auto", *files, *args_to_pass],
         cwd=check_utils.root_dir,
     )
 


### PR DESCRIPTION
changes the argument order in the subprocess call to pytest to allow manually overriding of the number of threads (or disabling multithreading altogether with `pytest_.py .... -n0`)

partially addresses #990, but as per that issue we should also consider changing the default (and maybe even choosing it dynamically based on the number of files we're testing?)