### PR TITLE
Enable docparams checks

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -128,6 +128,13 @@ enable = [
   "yield-outside-function",
 ]
 
+# Enable the optional checks by parameter_documentation
+[tool.pylint.parameter_documentation]
+accept-no-param-doc=false # Do not accept totally missing parameter documentation.
+accept-no-raise-doc=false # Do not accept totally missing raises documentation.
+accept-no-return-doc=false # Do not accept totally missing return documentation.
+accept-no-yield-doc=false # Do not accept missing yields annotations.
+
 # Ignore long lines containing urls or pylint directives.
 [tool.pylint.format]
 ignore-long-lines = '^(.*#\w*pylint: disable.*|\s*(# )?<?https?://\S+>?)$'

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -16,6 +16,11 @@ import cirq_superstaq as css
 
 @pytest.fixture
 def service() -> css.Service:
+    """Fixture for cirq_suerstaq service.
+
+    Return:
+        A cirq_superstaq service instance.
+    """
     return css.Service()
 
 
@@ -306,7 +311,11 @@ def test_submit_to_provider_simulators(target: str, service: css.Service) -> Non
 
 @pytest.mark.skip(reason="Can't be executed when Sqorpius is set to not accept jobs")
 def test_submit_to_sqorpius_qubit_sorting(service: css.Service) -> None:
-    """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""
+    """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776
+
+    Args:
+        service: cirq_superstaq service object from fixture.
+    """
     target = "cq_sqorpius_qpu"
     num_qubits = service.target_info(target)["num_qubits"]
     qubits = cirq.LineQubit.range(num_qubits)

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -16,7 +16,7 @@ import cirq_superstaq as css
 
 @pytest.fixture
 def service() -> css.Service:
-    """Fixture for cirq_suerstaq service.
+    """Fixture for cirq_superstaq service.
 
     Return:
         A cirq_superstaq service instance.

--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -26,6 +26,11 @@ import cirq_superstaq as css
 
 @pytest.fixture
 def job() -> css.Job:
+    """Fixture for cirq_superstaq Job.
+
+    Returns:
+        A cirq_superstaq Job instance.
+    """
     client = gss.superstaq_client._SuperstaqClient(
         client_name="cirq-superstaq",
         remote_host="http://example.com",
@@ -35,6 +40,11 @@ def job() -> css.Job:
 
 
 def new_job() -> css.Job:
+    """Creates a new cirq_superstaq Job instance.
+
+    Returns:
+        A cirq_superstaq Job instance.
+    """
     client = gss.superstaq_client._SuperstaqClient(
         client_name="cirq-superstaq",
         remote_host="http://example.com",
@@ -47,6 +57,12 @@ def mocked_get_job_requests(*job_dicts: dict[str, Any]) -> mock._patch[mock.Mock
     """Mocks the server's response to `get_job` requests using the given sequence of job_dicts.
     Return type is wrapped in a string because "'type' object is not subscriptable"
     is thrown at runtime
+
+    Args:
+        job_dicts: stores details about the job.
+
+    Returns:
+        A mock patch that returns the provided job_dicts.
     """
     return mock.patch(
         "general_superstaq.superstaq_client._SuperstaqClient.get_job", side_effect=job_dicts

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -274,7 +274,11 @@ class VirtualZPowGate(cirq.EigenGate):
 
     @property
     def dimension(self) -> int:
-        """The qudit dimension on which this gate acts."""
+        """The qudit dimension on which this gate acts.
+
+        Returns:
+            The gate's dimension.
+        """
         return self._dimension
 
     @property
@@ -283,6 +287,9 @@ class VirtualZPowGate(cirq.EigenGate):
         a phase of `(-1)**exponent` will be applied to energy levels `[2, ..., dimension - 1]`. This
         is equivalent to phase shifting all subsequent single-qudit gates acting in the `(1, 2)`
         subspace (assuming all other gates commute with this one).
+
+        Returns:
+            The lowest energy level onto which this gate applies a phase.
         """
         return self._level
 

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
@@ -210,7 +210,10 @@ def test_qutrit_cz_pow_gate() -> None:
 
 @pytest.mark.parametrize("dimension", [2, 3, 4, 5, 6])
 def test_qutrit_cz_pow_gate_implementation_for_other_qudits(dimension: int) -> None:
-    """Confirm that QutritCZPowGate._eigen_components_() would work for any dimension."""
+    """Confirm that QutritCZPowGate._eigen_components_() would work for any dimension.
+    Args:
+        dimension: The gate dimension for the current test.
+    """
     with mock.patch("cirq_superstaq.QutritCZPowGate.dimension", dimension):
         gate = css.QutritCZPowGate()
         assert gate.dimension == dimension

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -1101,7 +1101,7 @@ class Service(gss.service.Service):
 
         if not no_submit_target:
 
-            def objective(
+            def _objective(
                 x: np.typing.NDArray[np.int_], A: float, p: float
             ) -> np.typing.NDArray[np.float_]:
                 return A * p**x
@@ -1110,7 +1110,7 @@ class Service(gss.service.Service):
 
             e_f = 0.0
             for ps, y_vals in cb_data["process_fidelity_data"]["averages"].items():
-                popt, _ = curve_fit(objective, instance_information["depths"], y_vals)
+                popt, _ = curve_fit(_objective, instance_information["depths"], y_vals)
                 A, p = popt
                 A = round(A, 2)
                 fit_data["A_" + str(ps)] = A
@@ -1145,7 +1145,7 @@ class Service(gss.service.Service):
         legend_colors = []
         plt.xlim(0, x_values[-1] + 4)
 
-        def objective(
+        def _objective(
             x: np.typing.NDArray[np.int_], A: float, p: float
         ) -> np.typing.NDArray[np.float_]:
             return A * p**x
@@ -1168,7 +1168,7 @@ class Service(gss.service.Service):
                     )
             plt.plot(
                 np.arange(0, x_values[-1] + 4),
-                objective(np.arange(0, x_values[-1] + 4), A, p),
+                _objective(np.arange(0, x_values[-1] + 4), A, p),
             )
             e_f += p
             if legend_labels_count < max_legend_labels:

--- a/general-superstaq/general_superstaq/service.py
+++ b/general-superstaq/general_superstaq/service.py
@@ -88,6 +88,9 @@ class Service:
             email: The new user's email.
             balance: The new balance.
 
+        Raises:
+            SuperstaqException: If requested balance exceeds the limit.
+
         Returns:
             String containing status of update (whether or not it failed).
         """

--- a/qiskit-superstaq/qiskit_superstaq/conftest.py
+++ b/qiskit-superstaq/qiskit_superstaq/conftest.py
@@ -117,6 +117,13 @@ class MockSuperstaqProvider(qss.SuperstaqProvider):
         )
 
     def get_backend(self, name: str) -> MockSuperstaqBackend:
+        """Mocks the get_backend function of SuperstaqProvider.
+        Args:
+            name: name of the backend.
+
+        Returns:
+            A mock superstaq backend with the given name.
+        """
         return MockSuperstaqBackend(self, name)
 
 

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -16,6 +16,11 @@ import qiskit_superstaq as qss
 
 @pytest.fixture
 def provider() -> qss.SuperstaqProvider:
+    """Fixture for the qiskit superstaq provider.
+
+    Returns:
+        A qiskit_superstaq provider instance.
+    """
     return qss.SuperstaqProvider()
 
 
@@ -274,7 +279,10 @@ def test_submit_dry_run(target: str, provider: qss.SuperstaqProvider) -> None:
 
 @pytest.mark.skip(reason="Can't be executed when Sqorpius is set to not accept jobs")
 def test_submit_to_sqorpius_qubit_sorting(provider: qss.SuperstaqProvider) -> None:
-    """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776"""
+    """Regression test for https://github.com/Infleqtion/client-superstaq/issues/776
+
+    Args:
+        provider: qiskit_superstaq instance from the fixture."""
     backend = provider.get_backend("cq_sqorpius_qpu")
 
     num_qubits = backend.configuration().n_qubits

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
@@ -15,11 +15,26 @@ if TYPE_CHECKING:
 
 
 def mock_response(status_str: str) -> dict[str, str | int | dict[str, int]]:
+    """Mock response for requests.
+
+    Args:
+        status_str: the value for the status key.
+
+    Returns:
+        A mock response.
+    """
     return {"status": status_str, "samples": {"11": 50, "10": 50}, "shots": 100}
 
 
 @pytest.fixture
 def backend(fake_superstaq_provider: MockSuperstaqProvider) -> qss.SuperstaqBackend:
+    """Fixture for qiskit_superstaq backend.
+
+    Args:
+        fake_superstaq_provider: the mocked SuperstaqProvider.
+
+    Returns:
+        A mocked SuperstaqBackend."""
     return fake_superstaq_provider.get_backend("ss_example_qpu")
 
 

--- a/supermarq-benchmarks/supermarq/benchmark.py
+++ b/supermarq-benchmarks/supermarq/benchmark.py
@@ -26,11 +26,15 @@ class Benchmark:
         """Returns the quantum circuit(s) corresponding to the current benchmark parameters."""
 
     def cirq_circuit(self) -> cirq.Circuit | list[cirq.Circuit]:
-        """Returns the cirq circuit(s) corresponding to the current benchmark parameters."""
+        """Returns:
+        The cirq circuit(s) corresponding to the current benchmark parameters.
+        """
         return self.circuit()
 
     def qiskit_circuit(self) -> qiskit.QuantumCircuit | list[qiskit.QuantumCircuit]:
-        """Returns the qiskit circuit(s) corresponding to the current benchmark parameters."""
+        """Returns:
+        The qiskit circuit(s) corresponding to the current benchmark parameters.
+        """
         cirq_circuit = self.cirq_circuit()
         if isinstance(cirq_circuit, cirq.Circuit):
             return supermarq.converters.cirq_to_qiskit(cirq_circuit)

--- a/supermarq-benchmarks/supermarq/benchmark_test.py
+++ b/supermarq-benchmarks/supermarq/benchmark_test.py
@@ -12,14 +12,29 @@ from supermarq.benchmark import Benchmark
 
 @pytest.fixture
 def benchmark() -> Benchmark:
-    """Simple one-qubit benchmark that creates an equal superposition state"""
+    """Simple one-qubit benchmark that creates an equal superposition state
+
+    Returns:
+        A benchmark instance.
+    """
 
     class _TestBenchmark(Benchmark):
         def circuit(self) -> cirq.Circuit:
+            """Returns:
+            A test cirq circuit of an equal superposition state.
+            """
             qubit = cirq.LineQubit(0)
             return cirq.Circuit(cirq.H(qubit), cirq.measure(qubit))
 
         def score(self, counts: Mapping[str, float]) -> float:
+            """Device performace score.
+
+            Args:
+                counts: Dictionary(s) containing the measurement counts from execution.
+
+            Returns:
+                a normalized [0,1] score reflecting device performance.
+            """
             dist = {b: c / sum(counts.values()) for b, c in counts.items()}
             return hellinger_fidelity({"0": 0.5, "1": 0.5}, dist)
 

--- a/supermarq-benchmarks/supermarq/benchmarks/qaoa_vanilla_proxy.py
+++ b/supermarq-benchmarks/supermarq/benchmarks/qaoa_vanilla_proxy.py
@@ -99,6 +99,7 @@ class QAOAVanillaProxy(Benchmark):
             """The objective function to minimize.
 
             Args:
+                params: parameters for objective.
 
             Returns:
                 Evaluation of objective given parameters.

--- a/supermarq-benchmarks/supermarq/plotting.py
+++ b/supermarq-benchmarks/supermarq/plotting.py
@@ -424,6 +424,9 @@ class RadarAxesMeta(PolarAxes):
         Args:
             args: Desired arguments for plotting.
             kwargs: Other desired keyword arguments for plotting.
+
+        Returns:
+            New closed lines.
         """
         lines = super().plot(*args, **kwargs)
         for line in lines:


### PR DESCRIPTION
Although we import the `docparams` plugin from pylint's extensions, the checks for ensuring docstrings contain return, yield, parameter, and raise documentation are optional and not enabled. We have been enforcing the inclusion of these through pr reviews.