### PR TITLE
barriers should never commute

### DIFF
--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -215,7 +215,9 @@ def test_pulse_gate_circuits_invalid_circuit(job: css.job.Job) -> None:
 
     # The first call will trigger a refresh:
     with patched_requests({"job_id": job_dict}):
-        with pytest.raises(ValueError, match="circuits could not be deserialized."):
+        with pytest.raises(ValueError, match="circuits could not be deserialized."), pytest.warns(
+            match="pulse gate circuit could not be deserialized"
+        ):
             job.pulse_gate_circuits()
 
 

--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Set
+from collections.abc import Iterator, Sequence, Set
 from typing import Any
 
 import cirq
@@ -412,6 +412,18 @@ class Barrier(cirq.ops.IdentityGate, cirq.InterchangeableQubitsGate):
 
     def _decompose_(self, qubits: tuple[cirq.Qid, ...]) -> cirq.type_workarounds.NotImplementedType:
         return NotImplemented
+
+    def _commutes_(self, other: object, atol: float = 1e-8) -> bool:
+        """By definition nothing commutes with a barrier."""
+        _, _ = other, atol
+        return False
+
+    def _commutes_on_qids_(
+        self, qids: Sequence[cirq.Qid], other: object, atol: float = 1e-8
+    ) -> bool:
+        """By definition nothing commutes with a barrier."""
+        _, _, _ = qids, other, atol
+        return False
 
     def _trace_distance_bound_(self) -> float:
         return 1.0

--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates_test.py
@@ -545,6 +545,11 @@ def test_barrier() -> None:
     assert str(gate) == "Barrier(3)"
     assert repr(gate) == "css.Barrier(3)"
 
+    assert not cirq.commutes(css.Barrier(1), cirq.I)
+    assert not cirq.commutes(cirq.Z, css.Barrier(1))
+    assert not cirq.commutes(css.barrier(*qubits), cirq.I(qubits[1]))
+    assert not cirq.commutes(cirq.Z(qubits[2]), css.barrier(*qubits))
+
     cirq.testing.assert_equivalent_repr(gate, setup_code="import cirq_superstaq as css")
 
     operation = gate.on(*qubits)


### PR DESCRIPTION
adds `_commutes_` and `_commutes_on_qids_` magic methods to `css.Barrier` to indicate that barriers should never commute

(also adds one line in `job_test.py` to prevent a superfluous warning from appearing in the pytest output)