### PR TITLE
fix qcvv progress bars when using cli

### DIFF
--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
@@ -24,7 +24,7 @@ from typing import Any, Generic, TypeVar
 import cirq
 import cirq_superstaq as css
 import pandas as pd
-from tqdm.notebook import tqdm
+from tqdm.auto import tqdm
 
 
 @dataclass

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from unittest.mock import MagicMock, call, patch
 
@@ -36,11 +35,6 @@ class ExampleResults(BenchmarkingResults):
     example: float
 
     experiment_name = "Example results"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def patch_tqdm() -> None:
-    os.environ["TQDM_DISABLE"] = "1"
 
 
 @pytest.fixture

--- a/supermarq-benchmarks/supermarq/qcvv/conftest.py
+++ b/supermarq-benchmarks/supermarq/qcvv/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def patch_tqdm() -> Generator[None, None, None]:
+    """Disable progress bars during tests."""
+    with mock.patch.dict(os.environ, {"TQDM_DISABLE": "1"}):
+        yield

--- a/supermarq-benchmarks/supermarq/qcvv/irb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/irb.py
@@ -26,8 +26,8 @@ import numpy as np
 import pandas as pd
 import scipy
 import seaborn as sns
+from tqdm.auto import trange
 from tqdm.contrib.itertools import product
-from tqdm.notebook import tqdm
 
 from supermarq.qcvv.base_experiment import BenchmarkingExperiment, BenchmarkingResults, Sample
 
@@ -408,7 +408,7 @@ class IRB(BenchmarkingExperiment[Union[IRBResults, RBResults]]):
         """
         sample = [
             self._clifford_gate_to_circuit(self.random_clifford())
-            for _ in tqdm(range(samples), desc="Sampling Clifford operations")
+            for _ in trange(samples, desc="Sampling Clifford operations")
         ]
         return {
             "single_qubit_gates": np.mean(

--- a/supermarq-benchmarks/supermarq/qcvv/irb_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/irb_test.py
@@ -16,7 +16,6 @@
 # mypy: disable-error-code="union-attr"
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, patch
 
 import cirq
@@ -26,11 +25,6 @@ import pytest
 import supermarq.qcvv.irb
 from supermarq.qcvv.base_experiment import Sample
 from supermarq.qcvv.irb import IRB
-
-
-@pytest.fixture(scope="session", autouse=True)
-def patch_tqdm() -> None:
-    os.environ["TQDM_DISABLE"] = "1"
 
 
 def test_irb_init() -> None:

--- a/supermarq-benchmarks/supermarq/qcvv/xeb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb.py
@@ -24,8 +24,7 @@ import numpy as np
 import pandas as pd
 import scipy
 import seaborn as sns
-import tqdm
-import tqdm.contrib
+import tqdm.auto
 import tqdm.contrib.itertools
 
 from supermarq.qcvv import BenchmarkingExperiment, BenchmarkingResults, Sample
@@ -252,7 +251,7 @@ class XEB(BenchmarkingExperiment[XEBResults]):
             sample.sample_probabilities = sample.probabilities
             sample.probabilities = {}
 
-        for sample in tqdm.notebook.tqdm(samples, desc="Evaluating circuits"):
+        for sample in tqdm.auto.tqdm(samples, desc="Evaluating circuits"):
             sample.target_probabilities = self._simulate_sample(sample)
 
         records = []

--- a/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import itertools
-import os
 from unittest.mock import MagicMock, patch
 
 import cirq
@@ -25,11 +24,6 @@ import pandas as pd
 import pytest
 
 from supermarq.qcvv import XEB, XEBSample
-
-
-@pytest.fixture(scope="session", autouse=True)
-def patch_tqdm() -> None:
-    os.environ["TQDM_DISABLE"] = "1"
 
 
 def test_xeb_init() -> None:


### PR DESCRIPTION
currently some progress bars only work correctly in a notebook environment. this is fixed by importing from `tqdm.auto` instead of `tqdm.notebook`

also moves `patch_tqdm` to qcvv/conftest.py to avoid repetition in each test file