### PR TITLE
pass service kwargs to get_targets

### DIFF
--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -296,7 +296,9 @@ class _SuperstaqClient:
         Returns:
             A list of Superstaq targets matching all provided criteria.
         """
-        json_dict = {key: value for key, value in kwargs.items() if value is not None}
+        json_dict: dict[str, str | bool] = {
+            key: value for key, value in kwargs.items() if value is not None
+        }
         if self.client_kwargs:
             json_dict["options"] = json.dumps(self.client_kwargs)
 

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -296,8 +296,11 @@ class _SuperstaqClient:
         Returns:
             A list of Superstaq targets matching all provided criteria.
         """
-        target_filters = {key: value for key, value in kwargs.items() if value is not None}
-        superstaq_targets = self.post_request("/targets", target_filters)["superstaq_targets"]
+        json_dict = {key: value for key, value in kwargs.items() if value is not None}
+        if self.client_kwargs:
+            json_dict["options"] = json.dumps(self.client_kwargs)
+
+        superstaq_targets = self.post_request("/targets", json_dict)["superstaq_targets"]
         target_list = [
             gss.Target(target=target_name, **properties)
             for target_name, properties in superstaq_targets.items()

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -532,6 +532,34 @@ def test_superstaq_client_get_targets(mock_post: mock.MagicMock) -> None:
     )
     response = client.get_targets()
     assert response == RETURNED_TARGETS
+    mock_post.assert_called_once_with(
+        f"http://example.com/{API_VERSION}/targets",
+        headers=EXPECTED_HEADERS,
+        verify=False,
+        json={},
+    )
+
+    response = client.get_targets(simulator=True)
+    mock_post.assert_called_with(
+        f"http://example.com/{API_VERSION}/targets",
+        headers=EXPECTED_HEADERS,
+        verify=False,
+        json={"simulator": True},
+    )
+
+    client = gss.superstaq_client._SuperstaqClient(
+        client_name="general-superstaq",
+        remote_host="http://example.com",
+        api_key="to_my_heart",
+        ibmq_token="token",
+    )
+    response = client.get_targets(simulator=True)
+    mock_post.assert_called_with(
+        f"http://example.com/{API_VERSION}/targets",
+        headers=EXPECTED_HEADERS,
+        verify=False,
+        json={"simulator": True, "options": json.dumps({"ibmq_token": "token"})},
+    )
 
 
 @mock.patch("requests.Session.post")


### PR DESCRIPTION
allows users to see targets available with provided credentials