### PR TITLE
allow locations in requirements files

### DIFF
--- a/checks-superstaq/checks_superstaq/requirements.py
+++ b/checks-superstaq/checks_superstaq/requirements.py
@@ -137,7 +137,7 @@ def _are_pip_requirements(requirements: list[str]) -> bool:
 
 
 def _get_package_name(requirement: str) -> str:
-    return re.split(">|<|~|=", requirement)[0]
+    return re.split(r"[><~=@]", requirement)[0]
 
 
 def _sort_requirements(requirements: list[str]) -> tuple[bool, list[str]]:


### PR DESCRIPTION
pip allows packages to be specified by location (e.g. a git repo), but this will fail the requirements check because `@` isn't a version restriction