### PR TITLE
Fix spurious colon

### DIFF
--- a/docs/source/_static/css/docs-superstaq.css
+++ b/docs/source/_static/css/docs-superstaq.css
@@ -3645,7 +3645,7 @@ html{
     letter-spacing:0.5px;
     font-family:Helvetica Neue,Arial,sans-serif
     white-space:nowrap
-    
+
 }
 .wy-menu-vertical ul{
     margin-bottom:0
@@ -4926,4 +4926,7 @@ span.linenos.special { color: #303030; background-color: #ECECEC; padding-left: 
         grid-row-start: 3;
         grid-row-end: 4;
     }
+}
+.colon {
+    display:none;
 }


### PR DESCRIPTION
Fixes the spurious colons generated in the API summary in the docs. Achieved by hiding the `colon` class in our `.css`.

Supercedes https://github.com/Infleqtion/client-superstaq/pull/944