### PR TITLE
Update symengine version to 0.13.0

### DIFF
--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -1,3 +1,3 @@
 general-superstaq~=0.5.30
 qiskit>=1.0.0
-symengine~=0.11.0
+symengine~=0.13.0


### PR DESCRIPTION
Solving #1080. Locally ran the `resource_esitmate.ipynb`, `qscout_tutorial.ipynb`, and basic submissions to backends successfully with the updated pin.