### PR TITLE
Fixing headers in EeroQ demo notebooks

### DIFF
--- a/docs/source/optimizations/eeroq/eeroq_css.ipynb
+++ b/docs/source/optimizations/eeroq/eeroq_css.ipynb
@@ -82,7 +82,7 @@
    "id": "275bcdda-0eef-41c0-b7ea-017accab90eb",
    "metadata": {},
    "source": [
-    "# EeroQ Gates"
+    "## EeroQ Gates"
    ]
   },
   {
@@ -319,7 +319,7 @@
    "id": "7cb64f54-69d8-417f-9b1d-38a5900e5b7f",
    "metadata": {},
    "source": [
-    "# Circuit Compilation"
+    "## Circuit Compilation"
    ]
   },
   {
@@ -532,7 +532,7 @@
    "id": "cd09e5d5-60f2-4361-b879-f2479df82e70",
    "metadata": {},
    "source": [
-    "# Circuit Simulation"
+    "## Circuit Simulation"
    ]
   },
   {

--- a/docs/source/optimizations/eeroq/eeroq_qss.ipynb
+++ b/docs/source/optimizations/eeroq/eeroq_qss.ipynb
@@ -82,7 +82,7 @@
    "id": "275bcdda-0eef-41c0-b7ea-017accab90eb",
    "metadata": {},
    "source": [
-    "# EeroQ Gates"
+    "## EeroQ Gates"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "id": "7cb64f54-69d8-417f-9b1d-38a5900e5b7f",
    "metadata": {},
    "source": [
-    "# Circuit Compilation"
+    "## Circuit Compilation"
    ]
   },
   {
@@ -348,7 +348,7 @@
    "id": "cd09e5d5-60f2-4361-b879-f2479df82e70",
    "metadata": {},
    "source": [
-    "# Circuit Simulation"
+    "## Circuit Simulation"
    ]
   },
   {


### PR DESCRIPTION
I accidentally set the subheadings to be headings, so the readthedocs contents list is inaccurate.
![image](https://github.com/user-attachments/assets/9520f517-9fdd-438a-b73f-0f2072b23d48)
