### PR TITLE
Add option to retrieve stored ibm credentials #799

### DIFF
--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -31,6 +31,7 @@ import cirq_superstaq as css
 
 if TYPE_CHECKING:
     from _typeshed import SupportsItems
+    from qiskit_ibm_provider import IBMProvider
 
 
 def _to_matrix_gate(matrix: npt.ArrayLike) -> cirq.MatrixGate:
@@ -138,6 +139,8 @@ class Service(gss.service.Service):
         ibmq_token: str | None = None,
         ibmq_instance: str | None = None,
         ibmq_channel: str | None = None,
+        ibmq_provider: IBMProvider | None = None,
+        use_stored_ibmq_credentials: bool = False,
         **kwargs: object,
     ) -> None:
         """Creates the Service to access Superstaq's API.
@@ -187,6 +190,8 @@ class Service(gss.service.Service):
             ibmq_token=ibmq_token,
             ibmq_instance=ibmq_instance,
             ibmq_channel=ibmq_channel,
+            ibmq_provider=ibmq_provider,
+            use_stored_ibmq_credentials=use_stored_ibmq_credentials,
             **kwargs,
         )
 

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_provider.py
@@ -24,6 +24,7 @@ import qiskit_superstaq as qss
 
 if TYPE_CHECKING:
     from _typeshed import SupportsItems
+    from qiskit_ibm_provider import IBMProvider
 
 
 class SuperstaqProvider(gss.service.Service):
@@ -54,6 +55,8 @@ class SuperstaqProvider(gss.service.Service):
         ibmq_token: str | None = None,
         ibmq_instance: str | None = None,
         ibmq_channel: str | None = None,
+        ibmq_provider: IBMProvider | None = None,
+        use_stored_ibmq_credentials: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initializes a `SuperstaqProvider`.
@@ -101,6 +104,8 @@ class SuperstaqProvider(gss.service.Service):
             ibmq_token=ibmq_token,
             ibmq_instance=ibmq_instance,
             ibmq_channel=ibmq_channel,
+            ibmq_provider=ibmq_provider,
+            use_stored_ibmq_credentials=use_stored_ibmq_credentials,
             **kwargs,
         )
 


### PR DESCRIPTION
Adds the option to retrieve stored ibm credentials (#799) by either:

1. setting the `use_stored_ibm_credentials` parameter to `True` or
2. passing an `IBMProvider()` object instance to the `ibmq_provider` parameter. 

First the `use_stored_ibm_credentials` flag is checked then whether an `ibmq_provider` is provided. Finally, if neither are set, checks if `ibmq_token`, `ibmq_instance`, and `ibmq_channel` have been set manually. 