### PR TITLE
Format TOML files with taplo

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -134,10 +134,10 @@ enable = [
 
 # Enable the optional checks by parameter_documentation
 [tool.pylint.parameter_documentation]
-accept-no-param-doc=false # Do not accept totally missing parameter documentation.
-accept-no-raise-doc=false # Do not accept totally missing raises documentation.
-accept-no-return-doc=false # Do not accept totally missing return documentation.
-accept-no-yields-doc=false # Do not accept missing yields annotations.
+accept-no-param-doc = false       # Do not accept totally missing parameter documentation.
+accept-no-raise-doc = false       # Do not accept totally missing raises documentation.
+accept-no-return-doc = false      # Do not accept totally missing return documentation.
+accept-no-yields-doc = false      # Do not accept missing yields annotations.
 default-docstring-type = "google"
 
 # Ignore long lines containing urls or pylint directives.


### PR DESCRIPTION
`taplo fmt <file>` will format TOML files.

Maybe I should add https://pypi.org/project/taplo/ and use it in `checks/format_.py`?  Might not be worth the extra dependency though.

I mostly want this change because I want to format my TOML files in other projects (in particular, `pyproject.toml`), but that causes `checks/configs.py` to fail 🙂