### PR TITLE
Rename `circuit_index` in QCVV library

### DIFF
--- a/docs/source/apps/supermarq/qcvv/qcvv_css.ipynb
+++ b/docs/source/apps/supermarq/qcvv/qcvv_css.ipynb
@@ -140,7 +140,9 @@
     "        for index, depth in product(range(num_circuits), layers, desc=\"Building circuits.\"):\n",
     "            circuit = cirq.Circuit([cirq.Z(*self.qubits) for _ in range(depth)])\n",
     "            circuit += cirq.measure(*self.qubits)\n",
-    "            samples.append(Sample(circuit_index=index, circuit=circuit, data={\"depth\": depth}))\n",
+    "            samples.append(\n",
+    "                Sample(circuit_realization=index, circuit=circuit, data={\"depth\": depth})\n",
+    "            )\n",
     "\n",
     "        return samples"
    ]

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
@@ -35,9 +35,10 @@ class Sample:
     that is needed for analysis
     """
 
-    circuit_index: int
-    """The index of the circuit. There will be D samples with matching circuit index, one for each
-    cycle depth being measured. This index is useful for grouping results during analysis.
+    circuit_realization: int
+    """Indicates which realization of the random circuit this sameple is. There will be D samples
+    with matching circuit realization value, one for each cycle depth being measured. This index is
+    useful for grouping results during analysis.
     """
     circuit: cirq.Circuit
     """The raw (i.e. pre-compiled) sample circuit."""

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
@@ -36,7 +36,7 @@ class Sample:
     """
 
     circuit_realization: int
-    """Indicates which realization of the random circuit this sameple is. There will be D samples
+    """Indicates which realization of the random circuit this sample is. There will be D samples
     with matching circuit realization value, one for each cycle depth being measured. This index is
     useful for grouping results during analysis.
     """

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
@@ -425,7 +425,9 @@ class QCVVExperiment(ABC, Generic[ResultsT]):
             probabilities = self._canonicalize_probabilities(
                 {key: count / sum(hist.values()) for key, count in hist.items()}, self.num_qubits
             )
-            records.append({"circuit_index": sample.circuit_index, **sample.data, **probabilities})
+            records.append(
+                {"circuit_realization": sample.circuit_realization, **sample.data, **probabilities}
+            )
 
         return self._results_cls(
             target="local_simulator",

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
@@ -62,7 +62,9 @@ class ExampleExperiment(QCVVExperiment[ExampleResults]):
     def _build_circuits(self, num_circuits: int, cycle_depths: Iterable[int]) -> Sequence[Sample]:
         return [
             Sample(
-                circuit=MagicMock(spec=cirq.Circuit), data={"num": k, "depth": d}, circuit_index=k
+                circuit=MagicMock(spec=cirq.Circuit),
+                data={"num": k, "depth": d},
+                circuit_realization=k,
             )
             for k in range(num_circuits)
             for d in cycle_depths
@@ -89,12 +91,12 @@ def sample_circuits() -> list[Sample]:
         Sample(
             circuit=cirq.Circuit(cirq.CZ(*qubits), cirq.CZ(*qubits), cirq.measure(*qubits)),
             data={"circuit": 1},
-            circuit_index=1,
+            circuit_realization=1,
         ),
         Sample(
             circuit=cirq.Circuit(cirq.CX(*qubits), cirq.measure(*qubits)),
             data={"circuit": 2},
-            circuit_index=2,
+            circuit_realization=2,
         ),
     ]
 
@@ -258,8 +260,22 @@ def test_run_with_simulator(
         results.data,
         pd.DataFrame(
             [
-                {"circuit_index": 1, "circuit": 1, "00": 0.0, "01": 1.0, "10": 0.0, "11": 0.0},
-                {"circuit_index": 2, "circuit": 2, "00": 0.0, "01": 1.0, "10": 0.0, "11": 0.0},
+                {
+                    "circuit_realization": 1,
+                    "circuit": 1,
+                    "00": 0.0,
+                    "01": 1.0,
+                    "10": 0.0,
+                    "11": 0.0,
+                },
+                {
+                    "circuit_realization": 2,
+                    "circuit": 2,
+                    "00": 0.0,
+                    "01": 1.0,
+                    "10": 0.0,
+                    "11": 0.0,
+                },
             ]
         ),
     )
@@ -294,8 +310,22 @@ def test_run_with_simulator_default_target(
         results.data,
         pd.DataFrame(
             [
-                {"circuit_index": 1, "circuit": 1, "00": 0.0, "01": 1.0, "10": 0.0, "11": 0.0},
-                {"circuit_index": 2, "circuit": 2, "00": 0.0, "01": 1.0, "10": 0.0, "11": 0.0},
+                {
+                    "circuit_realization": 1,
+                    "circuit": 1,
+                    "00": 0.0,
+                    "01": 1.0,
+                    "10": 0.0,
+                    "11": 0.0,
+                },
+                {
+                    "circuit_realization": 2,
+                    "circuit": 2,
+                    "00": 0.0,
+                    "01": 1.0,
+                    "10": 0.0,
+                    "11": 0.0,
+                },
             ]
         ),
     )

--- a/supermarq-benchmarks/supermarq/qcvv/irb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/irb.py
@@ -688,7 +688,7 @@ class IRB(QCVVExperiment[_RBResultsBase]):
                         ),
                         "experiment": "RB",
                     },
-                    circuit_index=k,
+                    circuit_realization=k,
                 ),
             )
             if self.interleaved_gate is not None:
@@ -721,7 +721,7 @@ class IRB(QCVVExperiment[_RBResultsBase]):
                             ),
                             "experiment": "IRB",
                         },
-                        circuit_index=k,
+                        circuit_realization=k,
                     ),
                 )
         return samples

--- a/supermarq-benchmarks/supermarq/qcvv/irb_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/irb_test.py
@@ -156,7 +156,7 @@ def test_irb_build_circuit() -> None:
                     "single_qubit_gates": 4,
                     "two_qubit_gates": 0,
                 },
-                circuit_index=1,
+                circuit_realization=1,
             ),
             Sample(
                 circuit=cirq.Circuit(
@@ -189,7 +189,7 @@ def test_irb_build_circuit() -> None:
                     "single_qubit_gates": 6,
                     "two_qubit_gates": 0,
                 },
-                circuit_index=2,
+                circuit_realization=2,
             ),
             Sample(
                 circuit=cirq.Circuit(
@@ -216,7 +216,7 @@ def test_irb_build_circuit() -> None:
                     "single_qubit_gates": 4,
                     "two_qubit_gates": 0,
                 },
-                circuit_index=3,
+                circuit_realization=3,
             ),
             Sample(
                 circuit=cirq.Circuit(
@@ -252,7 +252,7 @@ def test_irb_build_circuit() -> None:
                     "single_qubit_gates": 7,
                     "two_qubit_gates": 0,
                 },
-                circuit_index=4,
+                circuit_realization=4,
             ),
         ]
 

--- a/supermarq-benchmarks/supermarq/qcvv/xeb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb.py
@@ -183,14 +183,14 @@ class XEBResults(QCVVResults):
         df2 = pd.melt(
             df,
             value_vars=["00", "01", "10", "11"],
-            id_vars=["cycle_depth", "circuit_index"],
+            id_vars=["cycle_depth", "circuit_realization"],
             var_name="bitstring",
         )
         fig, axs = plt.subplots(nrows=4, sharex=True)
         fig.subplots_adjust(hspace=0)
         for k, bitstring in enumerate(["00", "01", "10", "11"]):
             data = df2[df2["bitstring"] == bitstring].pivot(
-                index="circuit_index", columns="cycle_depth", values="value"
+                index="circuit_realization", columns="cycle_depth", values="value"
             )
             cmap = mpl.colormaps["rocket"]
             norm = mpl.colors.Normalize(0, 1)  # or vmin, vmax
@@ -351,7 +351,7 @@ class XEB(QCVVExperiment[XEBResults]):
                         "two_qubit_gate": str(self.two_qubit_gate),
                         **analytic_probabilities,
                     },
-                    circuit_index=k,
+                    circuit_realization=k,
                 )
             )
 

--- a/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
@@ -135,7 +135,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
     results.data = pd.DataFrame(
         [
             {
-                "circuit_index": 0,
+                "circuit_realization": 0,
                 "cycle_depth": 1,
                 "circuit_depth": 3,
                 "00": 1.0,
@@ -148,7 +148,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
                 "exact_11": 0.0,
             },
             {
-                "circuit_index": 1,
+                "circuit_realization": 1,
                 "cycle_depth": 1,
                 "circuit_depth": 3,
                 "00": 1.0,
@@ -161,7 +161,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
                 "exact_11": 0.0,
             },
             {
-                "circuit_index": 0,
+                "circuit_realization": 0,
                 "cycle_depth": 5,
                 "circuit_depth": 11,
                 "00": 0.0,
@@ -174,7 +174,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
                 "exact_11": 0.0,
             },
             {
-                "circuit_index": 1,
+                "circuit_realization": 1,
                 "cycle_depth": 5,
                 "circuit_depth": 11,
                 "00": 0.0,
@@ -187,7 +187,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
                 "exact_11": 0.25,
             },
             {
-                "circuit_index": 0,
+                "circuit_realization": 0,
                 "cycle_depth": 10,
                 "circuit_depth": 21,
                 "00": 0.0,
@@ -200,7 +200,7 @@ def test_xeb_analyse_results(xeb_experiment: XEB) -> None:
                 "exact_11": 0.25,
             },
             {
-                "circuit_index": 1,
+                "circuit_realization": 1,
                 "cycle_depth": 10,
                 "circuit_depth": 21,
                 "00": 0.0,


### PR DESCRIPTION
Rename `circuit_index` -> `circuit_realization` in the QCVV `Sample` object to avoid possible confusion 