### PR TITLE
bump min version of requests

### DIFF
--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.0
 pydantic>=1.10.7
-requests>=2.30.0
+requests>=2.32.0
 seaborn>=0.13.2


### PR DESCRIPTION
versions before 2.32.0 have known vulnerabilities: https://osv.dev/vulnerability/PYSEC-2023-74, https://osv.dev/vulnerability/GHSA-9wx4-h78v-vm56