### PR TITLE
Don't pass in `css.AceCR` to `daily_integration_test.py`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -26,11 +26,10 @@ def service() -> css.Service:
 
 
 def test_ibmq_compile(service: css.Service) -> None:
-    qubits = cirq.LineQubit.range(4)
+    qubits = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
-        css.AceCRMinusPlus(qubits[0], qubits[1]),
-        css.AceCRMinusPlus(qubits[1], qubits[2]),
-        css.AceCRMinusPlus(qubits[2], qubits[3]),
+        cirq.H(qubits[0]),
+        cirq.CX(qubits[0], qubits[1]),
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
@@ -52,11 +51,10 @@ def test_ibmq_compile(service: css.Service) -> None:
 
 def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qubits = cirq.LineQubit.range(4)
+    qubits = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
-        css.AceCRMinusPlus(qubits[0], qubits[1]),
-        css.AceCRMinusPlus(qubits[1], qubits[2]),
-        css.AceCRMinusPlus(qubits[2], qubits[3]),
+        cirq.H(qubits[0]),
+        cirq.CX(qubits[0], qubits[1]),
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -25,11 +25,12 @@ def service() -> css.Service:
     return css.Service()
 
 
-def test_ibmq_compile_pulse_gate_circuits(service: css.Service):
-    qubits = cirq.LineQubit.range(2)
+def test_ibmq_compile(service: css.Service) -> None:
+    qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        cirq.H(qubits[0]),
-        cirq.CX(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[1], qubits[2]),
+        css.AceCRMinusPlus(qubits[2], qubits[3]),
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
@@ -49,24 +50,6 @@ def test_ibmq_compile_pulse_gate_circuits(service: css.Service):
     assert len(out.pulse_gate_circuits[1].op_start_times) == len(out.pulse_gate_circuits[1])
 
 
-def test_ibmq_compile(service: css.Service) -> None:
-    qubits = cirq.LineQubit.range(4)
-    circuit = cirq.Circuit(
-        css.AceCRMinusPlus(qubits[0], qubits[1]),
-        css.AceCRMinusPlus(qubits[1], qubits[2]),
-        css.AceCRMinusPlus(qubits[2], qubits[3]),
-    )
-
-    out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
-    assert isinstance(out.circuit, cirq.Circuit)
-
-    out = service.ibmq_compile([circuit, circuit], target="ibmq_brisbane_qpu")
-
-    assert isinstance(out.circuits, list)
-    assert len(out.circuits) == 2
-    assert isinstance(out.circuits[1], cirq.Circuit)
-
-
 def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
     qubits = cirq.LineQubit.range(4)
@@ -79,6 +62,8 @@ def test_ibmq_compile_with_token() -> None:
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
 
     assert isinstance(out.circuit, cirq.Circuit)
+    assert isinstance(out.pulse_gate_circuit, qiskit.QuantumCircuit)
+    assert len(out.pulse_gate_circuit.op_start_times) == len(out.pulse_gate_circuit)
 
 
 def test_aqt_compile(service: css.Service) -> None:

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -25,7 +25,7 @@ def service() -> css.Service:
     return css.Service()
 
 
-def test_ibmq_compile(service: css.Service) -> None:
+def test_ibmq_compile_pulse_gate_circuits(service: css.Service):
     qubits = cirq.LineQubit.range(2)
     circuit = cirq.Circuit(
         cirq.H(qubits[0]),
@@ -49,19 +49,36 @@ def test_ibmq_compile(service: css.Service) -> None:
     assert len(out.pulse_gate_circuits[1].op_start_times) == len(out.pulse_gate_circuits[1])
 
 
+def test_ibmq_compile(service: css.Service) -> None:
+    qubits = cirq.LineQubit.range(4)
+    circuit = cirq.Circuit(
+        css.AceCRMinusPlus(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[1], qubits[2]),
+        css.AceCRMinusPlus(qubits[2], qubits[3]),
+    )
+
+    out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
+    assert isinstance(out.circuit, cirq.Circuit)
+
+    out = service.ibmq_compile([circuit, circuit], target="ibmq_brisbane_qpu")
+
+    assert isinstance(out.circuits, list)
+    assert len(out.circuits) == 2
+    assert isinstance(out.circuits[1], cirq.Circuit)
+
+
 def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qubits = cirq.LineQubit.range(2)
+    qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        cirq.H(qubits[0]),
-        cirq.CX(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[0], qubits[1]),
+        css.AceCRMinusPlus(qubits[1], qubits[2]),
+        css.AceCRMinusPlus(qubits[2], qubits[3]),
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
 
     assert isinstance(out.circuit, cirq.Circuit)
-    assert isinstance(out.pulse_gate_circuit, qiskit.QuantumCircuit)
-    assert len(out.pulse_gate_circuit.op_start_times) == len(out.pulse_gate_circuit)
 
 
 def test_aqt_compile(service: css.Service) -> None:

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -42,7 +42,7 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
     assert all(target in result for target in filtered_result)
 
 
-def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
+def test_ibmq_compile_pulse_gate_circuits(service: css.Service):
     qc = qiskit.QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
@@ -66,18 +66,35 @@ def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
     assert len(out.pulse_gate_circuits[1].op_start_times) == len(out.pulse_gate_circuits[1])
 
 
+def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
+    qc = qiskit.QuantumCircuit(4)
+    qc.append(qss.AceCR("-+"), [0, 1])
+    qc.append(qss.AceCR("-+"), [1, 2])
+    qc.append(qss.AceCR("-+"), [2, 3])
+
+    out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
+    assert isinstance(out, qss.compiler_output.CompilerOutput)
+    assert isinstance(out.circuit, qiskit.QuantumCircuit)
+
+    out = provider.ibmq_compile([qc, qc], target="ibmq_brisbane_qpu")
+    assert isinstance(out, qss.compiler_output.CompilerOutput)
+
+    assert isinstance(out.circuits, list)
+    assert len(out.circuits) == 2
+    assert isinstance(out.circuits[1], qiskit.QuantumCircuit)
+
+
 def test_ibmq_compile_with_token() -> None:
     provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qc = qiskit.QuantumCircuit(2)
-    qc.h(0)
-    qc.cx(0, 1)
+    qc = qiskit.QuantumCircuit(4)
+    qc.append(qss.AceCR("-+"), [0, 1])
+    qc.append(qss.AceCR("-+"), [1, 2])
+    qc.append(qss.AceCR("-+"), [2, 3])
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
 
     assert isinstance(out, qss.compiler_output.CompilerOutput)
     assert isinstance(out.circuit, qiskit.QuantumCircuit)
-    assert isinstance(out.pulse_gate_circuit, qiskit.QuantumCircuit)
-    assert len(out.pulse_gate_circuit.op_start_times) == len(out.pulse_gate_circuit)
 
 
 def test_aqt_compile(provider: qss.SuperstaqProvider) -> None:

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -42,7 +42,7 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
     assert all(target in result for target in filtered_result)
 
 
-def test_ibmq_compile_pulse_gate_circuits(provider: qss.SuperstaqProvider):
+def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
     qc = qiskit.QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)
@@ -66,35 +66,18 @@ def test_ibmq_compile_pulse_gate_circuits(provider: qss.SuperstaqProvider):
     assert len(out.pulse_gate_circuits[1].op_start_times) == len(out.pulse_gate_circuits[1])
 
 
-def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
-    qc = qiskit.QuantumCircuit(4)
-    qc.append(qss.AceCR("-+"), [0, 1])
-    qc.append(qss.AceCR("-+"), [1, 2])
-    qc.append(qss.AceCR("-+"), [2, 3])
-
-    out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
-    assert isinstance(out, qss.compiler_output.CompilerOutput)
-    assert isinstance(out.circuit, qiskit.QuantumCircuit)
-
-    out = provider.ibmq_compile([qc, qc], target="ibmq_brisbane_qpu")
-    assert isinstance(out, qss.compiler_output.CompilerOutput)
-
-    assert isinstance(out.circuits, list)
-    assert len(out.circuits) == 2
-    assert isinstance(out.circuits[1], qiskit.QuantumCircuit)
-
-
 def test_ibmq_compile_with_token() -> None:
     provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qc = qiskit.QuantumCircuit(4)
-    qc.append(qss.AceCR("-+"), [0, 1])
-    qc.append(qss.AceCR("-+"), [1, 2])
-    qc.append(qss.AceCR("-+"), [2, 3])
+    qc = qiskit.QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
 
     assert isinstance(out, qss.compiler_output.CompilerOutput)
     assert isinstance(out.circuit, qiskit.QuantumCircuit)
+    assert isinstance(out.pulse_gate_circuit, qiskit.QuantumCircuit)
+    assert len(out.pulse_gate_circuit.op_start_times) == len(out.pulse_gate_circuit)
 
 
 def test_aqt_compile(provider: qss.SuperstaqProvider) -> None:

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -42,7 +42,7 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
     assert all(target in result for target in filtered_result)
 
 
-def test_ibmq_compile_pulse_gate_circuits(service: css.Service):
+def test_ibmq_compile_pulse_gate_circuits(provider: qss.SuperstaqProvider):
     qc = qiskit.QuantumCircuit(2)
     qc.h(0)
     qc.cx(0, 1)

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -43,10 +43,9 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
 
 
 def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
-    qc = qiskit.QuantumCircuit(4)
-    qc.append(qss.AceCR("-+"), [0, 1])
-    qc.append(qss.AceCR("-+"), [1, 2])
-    qc.append(qss.AceCR("-+"), [2, 3])
+    qc = qiskit.QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
     assert isinstance(out, qss.compiler_output.CompilerOutput)
@@ -69,10 +68,9 @@ def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
 
 def test_ibmq_compile_with_token() -> None:
     provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qc = qiskit.QuantumCircuit(4)
-    qc.append(qss.AceCR("-+"), [0, 1])
-    qc.append(qss.AceCR("-+"), [1, 2])
-    qc.append(qss.AceCR("-+"), [2, 3])
+    qc = qiskit.QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
 


### PR DESCRIPTION
Not passing in `css.AceCR` cause they can't be serialized anymore.