### PR TITLE
Add models test

### DIFF
--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -95,12 +95,14 @@ UNSUCCESSFUL_CIRCUIT_STATES = [
 
 class DefaultPydanticModel(
     pydantic.BaseModel,
-    use_enum_values=True,
-    extra="ignore",
-    validate_assignment=True,
-    validate_default=True,
 ):
     """Default pydantic model used across the superstaq server."""
+    model_config = pydantic.ConfigDict(
+        use_enum_values=True,
+        extra="ignore",
+        validate_assignment=True,
+        validate_default=True,
+    )
 
 
 class JobData(DefaultPydanticModel):

--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -97,6 +97,7 @@ class DefaultPydanticModel(
     pydantic.BaseModel,
 ):
     """Default pydantic model used across the superstaq server."""
+
     model_config = pydantic.ConfigDict(
         use_enum_values=True,
         extra="ignore",

--- a/general-superstaq/general_superstaq/_models_test.py
+++ b/general-superstaq/general_superstaq/_models_test.py
@@ -7,7 +7,8 @@ import pytest
 from general_superstaq import _models
 
 """This test file will be updated once the new server (v0.3.0) client is implemented.
-For now, a single test is sufficient to check that `pydantic` is loading models and working as expected.
+For now, a single test is sufficient to check that `pydantic` is loading models and working as
+expected.
 """
 
 

--- a/general-superstaq/general_superstaq/_models_test.py
+++ b/general-superstaq/general_superstaq/_models_test.py
@@ -9,3 +9,4 @@ def test_user_token_response() -> None:
         email="cameron.booker@infleqtion.com",
         token="abc",
     )
+    

--- a/general-superstaq/general_superstaq/_models_test.py
+++ b/general-superstaq/general_superstaq/_models_test.py
@@ -1,0 +1,11 @@
+# pylint: disable=missing-function-docstring,missing-class-docstring
+from __future__ import annotations
+
+from general_superstaq import _models
+
+
+def test_user_token_response() -> None:
+    _models.UserTokenResponse(
+        email="cameron.booker@infleqtion.com",
+        token="abc",
+    )

--- a/general-superstaq/general_superstaq/_models_test.py
+++ b/general-superstaq/general_superstaq/_models_test.py
@@ -1,7 +1,14 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
 from __future__ import annotations
 
+import pydantic
+import pytest
+
 from general_superstaq import _models
+
+"""This test file will be updated once the new server (v0.3.0) client is implemented.
+For now a single test is sufficient to check that pydandic is loading models and working as expected
+"""
 
 
 def test_user_token_response() -> None:
@@ -9,4 +16,8 @@ def test_user_token_response() -> None:
         email="cameron.booker@infleqtion.com",
         token="abc",
     )
-    
+    with pytest.raises(pydantic.ValidationError):
+        _models.UserTokenResponse(
+            email="this is not an email",
+            token="abc",
+        )

--- a/general-superstaq/general_superstaq/_models_test.py
+++ b/general-superstaq/general_superstaq/_models_test.py
@@ -7,7 +7,7 @@ import pytest
 from general_superstaq import _models
 
 """This test file will be updated once the new server (v0.3.0) client is implemented.
-For now a single test is sufficient to check that pydandic is loading models and working as expected
+For now, a single test is sufficient to check that `pydantic` is loading models and working as expected.
 """
 
 

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.0
-pydantic>=1.10.7
+pydantic[email]>=1.10.7
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,5 +1,5 @@
+eval_type_backport>=0.2.2
 numpy>=1.21.0
 pydantic[email]>=2.10.6
 requests>=2.32.0
 seaborn>=0.13.2
-eval_type_backport>=0.2.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.21.0
 pydantic[email]>=2.10.6
 requests>=2.32.0
 seaborn>=0.13.2
+eval_type_backport>=0.2.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,5 +1,5 @@
 eval_type_backport>=0.2.2
 numpy>=1.21.0
-pydantic[email]>=2.5.0
+pydantic[email]>=2.10.6
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.0
-pydantic>=2.0.0
+pydantic>=1.10.7
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.21.0
 pydantic[email]>=1.10.7
 requests>=2.32.0
 seaborn>=0.13.2
+eval-type-backport>=0.2.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,5 +1,5 @@
 eval_type_backport>=0.2.2
 numpy>=1.21.0
-pydantic[email]>=2.10.6
+pydantic[email]>=2.6.0
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,5 +1,5 @@
 eval_type_backport>=0.2.2
 numpy>=1.21.0
-pydantic[email]>=2.10.6
+pydantic[email]>=2.5.0
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.21.0
-pydantic>=1.10.7
+pydantic>=2.0.0
 requests>=2.32.0
 seaborn>=0.13.2

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,5 +1,4 @@
 numpy>=1.21.0
-pydantic[email]>=1.10.7
+pydantic[email]>=2.10.6
 requests>=2.32.0
 seaborn>=0.13.2
-eval-type-backport>=0.2.2


### PR DESCRIPTION
Investigating https://github.com/Infleqtion/client-superstaq/issues/1171

What I found is as follows:
1. Pydantic V1 is quite out of date now and only has security patch updates. I suggest we move away from it (hence updated the requirements.txt to a much more recent  version of pydantic. 
2. In order for pydantic to play nicely with older versions of python (3.8 & 3.9) I needed to change how the default model config was implemented and add a package `eval_type_backport` which allows pydantic to recognize modern type hinting when running on older python versions (e.g. `list` rather than `typing.List` and `|` rather than `typing.Union`). Unfortunately pydantic does not seem to use `__future__annotations` natively.
3. I've now added a single test that checks whether pydantic can load models as expected. When we get round to implementing the updated client for the new server, these tests can be filled out to ensure coverage.