### PR TITLE
Drop `css.AceCRMinusPlus` in `css` integration test

### DIFF
--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -28,9 +28,8 @@ def service() -> css.Service:
 def test_ibmq_compile(service: css.Service) -> None:
     qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        css.AceCRMinusPlus(qubits[0], qubits[1]),
-        css.AceCRMinusPlus(qubits[1], qubits[2]),
-        css.AceCRMinusPlus(qubits[2], qubits[3]),
+        cirq.H(cirq.LineQubit(3)),
+        cirq.CX(cirq.LineQubit(3), cirq.LineQubit(0)) ** 0.7,
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
@@ -54,9 +53,8 @@ def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
     qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        css.AceCRMinusPlus(qubits[0], qubits[1]),
-        css.AceCRMinusPlus(qubits[1], qubits[2]),
-        css.AceCRMinusPlus(qubits[2], qubits[3]),
+        cirq.H(cirq.LineQubit(3)),
+        cirq.CX(cirq.LineQubit(3), cirq.LineQubit(0)) ** 0.7,
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -26,10 +26,9 @@ def service() -> css.Service:
 
 
 def test_ibmq_compile(service: css.Service) -> None:
-    qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        cirq.H(cirq.LineQubit(3)),
-        cirq.CX(cirq.LineQubit(3), cirq.LineQubit(0)) ** 0.7,
+        cirq.H(cirq.q(3)),
+        cirq.CX(cirq.q(3), cirq.q(0)) ** 0.7,
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
@@ -51,12 +50,10 @@ def test_ibmq_compile(service: css.Service) -> None:
 
 def test_ibmq_compile_with_token() -> None:
     service = css.Service(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qubits = cirq.LineQubit.range(4)
     circuit = cirq.Circuit(
-        cirq.H(cirq.LineQubit(3)),
-        cirq.CX(cirq.LineQubit(3), cirq.LineQubit(0)) ** 0.7,
+        cirq.H(cirq.q(3)),
+        cirq.CX(cirq.q(3), cirq.q(0)) ** 0.7,
     )
-
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
 
     assert isinstance(out.circuit, cirq.Circuit)


### PR DESCRIPTION
Fixes: https://github.com/Infleqtion/client-superstaq/issues/1173

Seems related to https://github.com/Infleqtion/client-superstaq/issues/1170, but calling the compiled pulse gate circuit on an input circuit such as:
```python
circuit = cirq.Circuit(
        css.AceCRMinusPlus(qubits[0], qubits[1]),
        css.AceCRMinusPlus(qubits[1], qubits[2]),
        css.AceCRMinusPlus(qubits[2], qubits[3]),
)
```
yields`None`.

Following https://github.com/Infleqtion/client-superstaq/pull/1169, this PR replaces the input circuit in the meantime till https://github.com/Infleqtion/client-superstaq/issues/1170 is addressed