### PR TITLE
Override equality comparisons for `cirq.EigenGate`'s post `cirq-core==1.5.0`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qubit_gates.py
@@ -358,7 +358,9 @@ class AceCR(cirq.Gate):
             cirq.PeriodicValue(self.sandwich_rx_rads, 4 * np.pi),
         )
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | NotImplementedType:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         if not isinstance(other, AceCR):
             return NotImplemented
 
@@ -552,7 +554,9 @@ class ParallelGates(cirq.Gate, cirq.InterchangeableQubitsGate):
     def _value_equality_values_(self) -> tuple[cirq.Gate, ...]:
         return self.component_gates
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         if not isinstance(other, ParallelGates):
             return NotImplemented
 
@@ -707,8 +711,10 @@ class RGate(cirq.PhasedXPowGate):
     def __pow__(self, power: cirq.TParamVal) -> RGate:
         return RGate(power * self.theta, self.phi)
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
-        """Implemented here because it isn't in cirq.PhasedXPowGate"""
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
+        """Implemented here because it isn't in `cirq.PhasedXPowGate`."""
         if not isinstance(other, cirq.PhasedXPowGate):
             return NotImplemented
 
@@ -809,8 +815,10 @@ class ParallelRGate(cirq.ParallelGate, cirq.InterchangeableQubitsGate):
     def __pow__(self, power: cirq.TParamVal) -> ParallelRGate:
         return ParallelRGate(power * self.theta, self.phi, self.num_copies)
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
-        """Implemented here because it isn't in cirq.ParallelGate"""
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
+        """Implemented here because it isn't in `cirq.ParallelGate`."""
         if not isinstance(other, cirq.ParallelGate):
             return NotImplemented
 

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Sequence, Set
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import cirq
 import numpy as np
@@ -11,6 +11,9 @@ import sympy
 from cirq.ops.common_gates import proper_repr
 
 import cirq_superstaq as css
+
+if TYPE_CHECKING:
+    from types import NotImplementedType
 
 
 def _subscript(n: int) -> str:
@@ -39,7 +42,9 @@ class QuditSwapGate(cirq.Gate, cirq.InterchangeableQubitsGate):
     def _value_equality_values_(self) -> int:
         return self.dimension
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         if isinstance(other, QuditSwapGate):
             return other.dimension == self.dimension
 
@@ -140,7 +145,9 @@ class BSwapPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
 
         return [(0.0, projector_rest), (0.5, projector_p), (-0.5, projector_n)]
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         """Workaround for https://github.com/quantumlib/Cirq/issues/5980."""
 
         if not isinstance(other, BSwapPowGate):
@@ -231,7 +238,9 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
     def _value_equality_values_(self) -> tuple[float, float]:
         return self._canonical_exponent, self._global_shift
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         """Workaround for https://github.com/quantumlib/Cirq/issues/5980."""
 
         if isinstance(other, QutritCZPowGate):
@@ -346,10 +355,9 @@ class VirtualZPowGate(cirq.EigenGate):
     def _value_equality_values_(self) -> tuple[object, ...]:
         return (*super()._value_equality_values_(), self._dimension, self._level)
 
-    def _value_equality_approximate_values_(self) -> tuple[object, ...]:
-        return (*super()._value_equality_approximate_values_(), self._dimension, self._level)
-
-    def _equal_up_to_global_phase_(self, other: object, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         if not isinstance(other, VirtualZPowGate):
             return NotImplemented
 
@@ -421,7 +429,9 @@ class _QutritZPowGate(cirq.EigenGate):
             wire_symbols=(wire_symbol,), exponent=self._diagram_exponent(args)
         )
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         """Workaround for https://github.com/quantumlib/Cirq/issues/5980."""
 
         if not isinstance(other, _QutritZPowGate):
@@ -606,7 +616,9 @@ class QubitSubspaceGate(cirq.Gate):
     ) -> tuple[cirq.Gate, tuple[int, ...], tuple[tuple[int, int], ...]]:
         return self.sub_gate, self.qid_shape, tuple(self.subspaces)
 
-    def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
+    def _equal_up_to_global_phase_(
+        self, other: Any, atol: float = 1e-8
+    ) -> NotImplementedType | bool:
         if not isinstance(other, QubitSubspaceGate):
             return NotImplemented
 

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -196,7 +196,7 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
         exponent: cirq.TParamVal = 1.0,
         global_shift: float = 0.0,
     ) -> None:
-        self._canonical_exponent_cached = None
+        self._canonical_exponent_cached: float | None = None
         super().__init__(exponent=exponent, global_shift=global_shift)
 
     @property
@@ -222,7 +222,7 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
         return eigen_components
 
     @property
-    def _canonical_exponent(self) -> float:
+    def _canonical_exponent(self) -> float | None:
         if self._canonical_exponent_cached is None:
             period = self._period()
             if not period:
@@ -235,7 +235,7 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
                 self._canonical_exponent_cached = self._exponent % period
         return self._canonical_exponent_cached
 
-    def _value_equality_values_(self) -> tuple[float, float]:
+    def _value_equality_values_(self) -> tuple[float | None, float]:
         return self._canonical_exponent, self._global_shift
 
     def _equal_up_to_global_phase_(

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -355,6 +355,14 @@ class VirtualZPowGate(cirq.EigenGate):
     def _value_equality_values_(self) -> tuple[object, ...]:
         return (*super()._value_equality_values_(), self._dimension, self._level)
 
+    def _value_equality_approximate_values_(self) -> tuple[object, ...]:
+        period = self._period()
+        if not period or cirq.is_parameterized(self._exponent):
+            exponent = self._exponent
+        else:
+            exponent = cirq.PeriodicValue(self._exponent, period)
+        return (exponent, self._global_shift, self._dimension, self._level)
+
     def _equal_up_to_global_phase_(
         self, other: Any, atol: float = 1e-8
     ) -> NotImplementedType | bool:

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates.py
@@ -7,6 +7,7 @@ from typing import Any
 import cirq
 import numpy as np
 import numpy.typing as npt
+import sympy
 from cirq.ops.common_gates import proper_repr
 
 import cirq_superstaq as css
@@ -183,6 +184,14 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
     Currently written for qutrits (d = 3), but its implementation should work for any dimension.
     """
 
+    def __init__(
+        self,
+        exponent: cirq.TParamVal = 1.0,
+        global_shift: float = 0.0,
+    ) -> None:
+        self._canonical_exponent_cached = None
+        super().__init__(exponent=exponent, global_shift=global_shift)
+
     @property
     def dimension(self) -> int:
         """Indicates that this gate acts on qutrits.
@@ -204,6 +213,23 @@ class QutritCZPowGate(cirq.EigenGate, cirq.InterchangeableQubitsGate):
             eigen_components.append((value, matrix))
 
         return eigen_components
+
+    @property
+    def _canonical_exponent(self) -> float:
+        if self._canonical_exponent_cached is None:
+            period = self._period()
+            if not period:
+                self._canonical_exponent_cached = self._exponent
+            elif cirq.is_parameterized(self._exponent):
+                self._canonical_exponent_cached = self._exponent
+                if isinstance(self._exponent, sympy.Number):
+                    self._canonical_exponent_cached = float(self._exponent)
+            else:
+                self._canonical_exponent_cached = self._exponent % period
+        return self._canonical_exponent_cached
+
+    def _value_equality_values_(self) -> tuple[float, float]:
+        return self._canonical_exponent, self._global_shift
 
     def _equal_up_to_global_phase_(self, other: Any, atol: float) -> bool | None:
         """Workaround for https://github.com/quantumlib/Cirq/issues/5980."""

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
@@ -331,7 +331,6 @@ def test_virtual_z_pow_gate() -> None:
     for i, gate in enumerate(fixed_gates):
         for other_gate in fixed_gates[:i]:
             assert not cirq.equal_up_to_global_phase(gate, other_gate)
-            assert not cirq.approx_eq(gate, other_gate)
 
     assert repr(css.VirtualZPowGate(dimension=3, level=1)) == "css.VirtualZPowGate(dimension=3)"
     assert (

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
@@ -10,6 +10,7 @@ import cirq
 import numpy as np
 import pytest
 import scipy.linalg
+import sympy
 
 import cirq_superstaq as css
 
@@ -155,6 +156,10 @@ def test_qutrit_cz_pow_gate() -> None:
 
     assert css.CZ3 == css.QutritCZPowGate()
     assert css.CZ3_INV == css.CZ3**-1 == css.CZ3**2
+
+    a = sympy.symbols("a")
+    CZ3_zero = css.QutritCZPowGate(exponent=0, global_shift=-1)
+    assert CZ3_zero == CZ3_zero**a
 
     assert css.CZ3 != shifted_cz3
     assert not cirq.approx_eq(css.CZ3, shifted_cz3)

--- a/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
+++ b/cirq-superstaq/cirq_superstaq/ops/qudit_gates_test.py
@@ -157,7 +157,7 @@ def test_qutrit_cz_pow_gate() -> None:
     assert css.CZ3 == css.QutritCZPowGate()
     assert css.CZ3_INV == css.CZ3**-1 == css.CZ3**2
 
-    a = sympy.symbols("a")
+    a = sympy.Symbol("a")
     CZ3_zero = css.QutritCZPowGate(exponent=0, global_shift=-1)
     assert CZ3_zero == CZ3_zero**a
 
@@ -331,6 +331,11 @@ def test_virtual_z_pow_gate() -> None:
     for i, gate in enumerate(fixed_gates):
         for other_gate in fixed_gates[:i]:
             assert not cirq.equal_up_to_global_phase(gate, other_gate)
+            assert not cirq.approx_eq(gate, other_gate)
+
+    phi = sympy.Symbol("phi")
+    test_gate = css.VirtualZPowGate(dimension=2, level=1, exponent=phi)
+    assert cirq.approx_eq(test_gate, fixed_gates[0] ** phi)
 
     assert repr(css.VirtualZPowGate(dimension=3, level=1)) == "css.VirtualZPowGate(dimension=3)"
     assert (
@@ -352,6 +357,7 @@ def test_virtual_z_pow_gate() -> None:
     assert str(css.VirtualZPowGate(dimension=4, level=2) ** 1.2) == "VZ(2+)**1.2"
     assert str(css.VirtualZPowGate(dimension=4, global_shift=0.5)) == "VZ(1+)"
     assert str(css.VirtualZPowGate(dimension=5, global_shift=0.5) ** 2.3) == "VZ(1+)**2.3"
+    assert str(css.VirtualZPowGate(dimension=5, exponent=phi)) == "VZ(1+)**phi"
 
     cirq.testing.assert_has_diagram(
         cirq.Circuit(css.VirtualZPowGate(dimension=3, level=1)(cirq.LineQid(0, 3))),

--- a/cirq-superstaq/requirements.txt
+++ b/cirq-superstaq/requirements.txt
@@ -1,2 +1,2 @@
-cirq-core>=1.0.0,<1.5.0
+cirq-core>=1.0.0
 general-superstaq~=0.5.39

--- a/supermarq-benchmarks/supermarq/qcvv/irb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/irb.py
@@ -373,7 +373,8 @@ class IRBResults(_RBResultsBase):
         if filename is not None:
             plt.savefig(filename)
 
-        root_figure = plot.figure.figure
+        root_figure = plot.get_figure()
+        assert root_figure is not None
         if filename is not None:
             root_figure.savefig(filename, bbox_inches="tight")
         return root_figure
@@ -451,7 +452,8 @@ class RBResults(_RBResultsBase):
             raise RuntimeError("No data stored. Cannot make plot.")
 
         plot = self._plot_results()
-        root_figure = plot.figure.figure
+        root_figure = plot.get_figure()
+        assert root_figure is not None
         if filename is not None:
             root_figure.savefig(filename, bbox_inches="tight")
         return root_figure


### PR DESCRIPTION
Fixes: https://github.com/Infleqtion/client-superstaq/issues/1180

This PR makes the following updates for compatibility with `cirq-core==1.5.0`:
- Updates the signature of `_equal_up_to_global_phase_` to be compatible with `cirq.Gate`.
- Overrides `_value_equality_values_` to follow the `cirq-core<1.5.0` implementation for `css.QutritCZPowGate()` (for now).
- Overrides `_value_equality_approximate_values_` to follow the `cirq-core<1.5.0` implementation for `css.VirtualZPowGate()` (for now).
- `mypy` typing issues in `supermarq-benchmarks/supermarq/qcvv/irb.py` raised after `cirq-core==1.5.0` upgrade 