### PR TITLE
Dropping Python 3.8 support (+ adding README badges)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     name: Pytest and Coverage check
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,10 +141,10 @@ jobs:
     name: ${{ matrix.type }} standalone coverage check with minimum dependency versions
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies, using minimum supported versions
         run: |
           min_versions=$(sed ${{ matrix.type }}/requirements.txt ${{ matrix.type }}/dev-requirements.txt -e 's/[~>]=\([0-9]\)/==\1/')

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/README.md
+++ b/README.md
@@ -3,62 +3,89 @@
   <img src="./docs/source/_static/logos/Superstaq_white.png#gh-dark-mode-only">
 </p>
 
-# Welcome to Superstaq!
+<div align="center">
+
+<a href="">[![License](https://img.shields.io/github/license/Infleqtion/client-superstaq?style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://github.com/Infleqtion/client-superstaq/blob/main/LICENSE)</a>
+<a href="">[![Python Versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13%20-141a5e?display_name=tag&style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://github.com/Infleqtion/client-superstaq)
+<a href="">[![GitHub Release](https://img.shields.io/github/v/release/Infleqtion/client-superstaq?display_name=tag&style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://github.com/Infleqtion/client-superstaq/releases)</a>
+<a href="">[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Infleqtion/client-superstaq/ci.yml?branch=main&style=flat&logo=github&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://github.com/Infleqtion/client-superstaq/actions/workflows/ci.yml)</a>
+<a href="">[![Read the docs](https://img.shields.io/badge/Read%20the%20docs-a?style=flat&logo=read-the-docs&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://superstaq.readthedocs.io/)</a>
+<a href="">[![Slack](https://img.shields.io/badge/Slack-slack?style=flat&logo=slack&logoColor=white&labelColor=00b198&color=141a5e#gh-light-mode-only)](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)</a>
+
+<a href="">[![License](https://img.shields.io/github/license/Infleqtion/client-superstaq?style=flat&logo=python&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://github.com/Infleqtion/client-superstaq/blob/main/LICENSE)</a>
+<a href="">[![Python Versions](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13%20-white?style=flat&logo=python&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://github.com/Infleqtion/client-superstaq)</a>
+<a href="">[![GitHub Release](https://img.shields.io/github/v/release/Infleqtion/client-superstaq?display_name=tag&style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://github.com/Infleqtion/client-superstaq/releases)</a>
+<a href="">[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Infleqtion/client-superstaq/ci.yml?branch=main&style=flat&logo=github&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://github.com/Infleqtion/client-superstaq/actions/workflows/ci.yml)</a>
+<a href="">[![Read the docs](https://img.shields.io/badge/Read%20the%20docs-a?style=flat&logo=read-the-docs&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://superstaq.readthedocs.io/)</a>
+<a href="">[![Slack](https://img.shields.io/badge/Slack-slack?style=flat&logo=slack&logoColor=white&labelColor=00b198&color=white#gh-dark-mode-only)](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw)</a>
+</div>
+
+# Welcome to Superstaq
+
 This repository is the home of the Superstaq development team's open-source work, which includes:
-* Our quantum software platform that is optimized across the quantum stack and enables users to write quantum programs in Cirq or Qiskit and target a variety of quantum computers and simulators. Read more about it [here](https://www.infleqtion.com/superstaq).
+
+- Our quantum software platform that is optimized across the quantum stack and enables users to write quantum programs in Cirq or Qiskit and target a variety of quantum computers and simulators. Read more about it [here](https://www.infleqtion.com/superstaq).
 
 <p align="center"><img src="docs/source/_static/svg/code.svg"></p>
 
 # Installation for users
+
 For installation instructions for users of Superstaq, check out [our documentation site](https://superstaq.readthedocs.io/)! In short, you can install any of our packages by doing `pip install <package>` in a terminal, where `<package>` is `qiskit-superstaq`, `cirq-superstaq`, or `general-superstaq`.
 
 # Installation for development
+
 If you'd like to contribute to Superstaq, below are the instructions for installation. Note, **if you are working on multiple clients** (e.g., `qiskit-superstaq` and `cirq-superstaq`), you do not need to clone the repository multiple times or set up multiple virtual environments, but you must install the client-specific requirements in each client directory.
 
 <details>
 <summary> <h3> <code>qiskit-superstaq</code> </h3> </summary>
-  
-  ```console
-  git clone git@github.com:Infleqtion/client-superstaq.git
-  python3 -m venv venv_superstaq
-  source venv_superstaq/bin/activate
-  cd client-superstaq/qiskit-superstaq
-  python3 -m pip install -e ".[dev]"
-  ```
+
+```console
+git clone git@github.com:Infleqtion/client-superstaq.git
+python3 -m venv venv_superstaq
+source venv_superstaq/bin/activate
+cd client-superstaq/qiskit-superstaq
+python3 -m pip install -e ".[dev]"
+```
+
 </details>
 
 <details>
 <summary> <h3> <code>cirq-superstaq</code> </h3> </summary>
-  
-  ```console
-  git clone git@github.com:Infleqtion/client-superstaq.git
-  python3 -m venv venv_superstaq
-  source venv_superstaq/bin/activate
-  cd client-superstaq/cirq-superstaq
-  python3 -m pip install -e ".[dev]"
-  ```
+
+```console
+git clone git@github.com:Infleqtion/client-superstaq.git
+python3 -m venv venv_superstaq
+source venv_superstaq/bin/activate
+cd client-superstaq/cirq-superstaq
+python3 -m pip install -e ".[dev]"
+```
+
 </details>
 
 <details>
 <summary> <h3> <code>general-superstaq</code> </h3> </summary>
-  
-  ```console
-  git clone git@github.com:Infleqtion/client-superstaq.git
-  python3 -m venv venv_superstaq
-  source venv_superstaq/bin/activate
-  cd client-superstaq/general-superstaq
-  python3 -m pip install -e ".[dev]"
-  ```
+
+```console
+git clone git@github.com:Infleqtion/client-superstaq.git
+python3 -m venv venv_superstaq
+source venv_superstaq/bin/activate
+cd client-superstaq/general-superstaq
+python3 -m pip install -e ".[dev]"
+```
+
 </details>
 
-# Documentation 
+# Documentation
+
 For more information on getting started, check out [our documentation site](https://superstaq.readthedocs.io/)!
 
 # License
+
 Superstaq is licensed under the Apache License 2.0. See our [LICENSE](https://github.com/Infleqtion/client-superstaq/blob/main/LICENSE) file for more details.
 
 # Contact Us
-If you'd like to reach out to a member of our team, please email us at superstaq@infleqtion.com or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw).
+
+If you'd like to reach out to a member of our team, please email us at <superstaq@infleqtion.com> or join our [Slack workspace](https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw).
 
 <p align="center" style="padding: 50px">
   <img src="./docs/source/_static/logos/Infleqtion_logo.png#gh-light-mode-only" style="width: 20%">

--- a/checks-superstaq/pyproject.toml
+++ b/checks-superstaq/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version", "dependencies"]
 
 [project.urls]

--- a/cirq-superstaq/README.md
+++ b/cirq-superstaq/README.md
@@ -12,7 +12,7 @@ features of Superstaq with this package.
 pip install cirq-superstaq
 ```
 
-Please note that Python version `3.9` or higher is required for `v0.6.0` or higher. For further installation instructions, see [here](https://github.com/Infleqtion/client-superstaq#readme).
+Please note that Python version `3.9` or higher is required. For further installation instructions, see [here](https://github.com/Infleqtion/client-superstaq#readme).
 
 ### Creating and submitting a circuit through cirq-superstaq
 

--- a/cirq-superstaq/README.md
+++ b/cirq-superstaq/README.md
@@ -12,9 +12,10 @@ features of Superstaq with this package.
 pip install cirq-superstaq
 ```
 
-Please note that Python version `3.8` or higher is required. For further installation instructions, see [here](https://github.com/Infleqtion/client-superstaq#readme).
+Please note that Python version `3.9` or higher is required for `v0.6.0` or higher. For further installation instructions, see [here](https://github.com/Infleqtion/client-superstaq#readme).
 
 ### Creating and submitting a circuit through cirq-superstaq
+
 ```python
 import cirq
 import cirq_superstaq as css

--- a/cirq-superstaq/docs/access.md
+++ b/cirq-superstaq/docs/access.md
@@ -2,11 +2,11 @@
 
 Cirq-Superstaq is used to access [Superstaq](https://www.infleqtion.com/superstaq) via a Web API through [Cirq](https://github.com/quantumlib/Cirq). Cirq programmers can take advantage of the applications, pulse level optimizations, and write-once-target-all features of Superstaq with this package.
 
-Please note that Python version `3.8` or higher is required.
+Please note that Python version `3.9` or higher is required.
 
 ## Accessing Cirq-Superstaq
 
-Creating and submitting a circuit through Cirq-Superstaq requires an API access token obtained at https://superstaq.infleqtion.com.
+Creating and submitting a circuit through Cirq-Superstaq requires an API access token obtained at <https://superstaq.infleqtion.com>.
 
 ## Next steps
 

--- a/cirq-superstaq/docs/getting_started_cirq_superstaq.ipynb
+++ b/cirq-superstaq/docs/getting_started_cirq_superstaq.ipynb
@@ -62,7 +62,7 @@
    "id": "20871935",
    "metadata": {},
    "source": [
-    "Please note that Python version `3.8` or higher is required. Creating and submitting a circuit through Cirq-Superstaq requires an API access token obtained at https://superstaq.infleqtion.com."
+    "Please note that Python version `3.9` or higher is required. Creating and submitting a circuit through Cirq-Superstaq requires an API access token obtained at https://superstaq.infleqtion.com."
    ]
   },
   {

--- a/cirq-superstaq/pyproject.toml
+++ b/cirq-superstaq/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -1,14 +1,14 @@
 Installation Guide
 ==================
-You can install Superstaq from PyPI in your terminal. Please note that Python version 3.8 or higher is required.
+You can install Superstaq from PyPI in your terminal. Please note that Python version 3.9 or higher is required.
 
-To install ``qiskit-superstaq``: 
+To install ``qiskit-superstaq``:
 
 .. code-block:: bash
-    
+
     pip install qiskit-superstaq
 
-To install ``cirq-superstaq``: 
+To install ``cirq-superstaq``:
 
 .. code-block:: bash
 

--- a/general-superstaq/pyproject.toml
+++ b/general-superstaq/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]

--- a/qiskit-superstaq/README.md
+++ b/qiskit-superstaq/README.md
@@ -12,7 +12,7 @@ features of Superstaq with this package.
 pip install qiskit-superstaq
 ```
 
-Please note that Python version `3.9` or higher is required for `v0.6.0` or higher. See installation instructions [here](https://github.com/Infleqtion/client-superstaq#readme).
+Please note that Python version `3.9` or higher is required. See installation instructions [here](https://github.com/Infleqtion/client-superstaq#readme).
 
 ### Creating and submitting a circuit through qiskit-superstaq
 

--- a/qiskit-superstaq/README.md
+++ b/qiskit-superstaq/README.md
@@ -12,9 +12,10 @@ features of Superstaq with this package.
 pip install qiskit-superstaq
 ```
 
-Please note that Python version `3.8` or higher is required. See installation instructions [here](https://github.com/Infleqtion/client-superstaq#readme).
+Please note that Python version `3.9` or higher is required for `v0.6.0` or higher. See installation instructions [here](https://github.com/Infleqtion/client-superstaq#readme).
 
 ### Creating and submitting a circuit through qiskit-superstaq
+
 ```python
 import qiskit
 import qiskit_superstaq as qss

--- a/qiskit-superstaq/pyproject.toml
+++ b/qiskit-superstaq/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]

--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -1,3 +1,3 @@
 general-superstaq~=0.5.39
-qiskit>=1.0.0,<2.0.0
+qiskit>=1.3.0,<2.0.0
 symengine~=0.13.0

--- a/qiskit-superstaq/requirements.txt
+++ b/qiskit-superstaq/requirements.txt
@@ -1,3 +1,3 @@
 general-superstaq~=0.5.39
-qiskit>=1.3.0,<2.0.0
+qiskit>=1.0.0,<2.0.0
 symengine~=0.13.0

--- a/supermarq-benchmarks/pyproject.toml
+++ b/supermarq-benchmarks/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dynamic = ["version", "dependencies", "optional-dependencies"]
 
 [project.urls]


### PR DESCRIPTION
This PR officially drops Python 3.8 support for all `client-superstaq` packages based on the need to drop Python 3.8 in https://github.com/Infleqtion/client-superstaq/pull/1178 (namely, supporting Qiskit `v2.0.0` requires `qiskit-superstaq`'s minimum qiskit support to be `v1.3.0`  (which has no Python 3.8 support) for QPY reasons).

Given Python 3.8 had reached [EOL](https://devguide.python.org/versions/) on 2024-10-07, this PR extends the requirement to at least Python 3.9 moving forward.

As a bonus, this PR includes new README badges to highlight the supported Python versions, as well as offering other useful at-a-glance information.