### PR TITLE
Ignore `eval_type_backport` if `python_version > '3.9'`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           python-version: 3.9
       - name: Install dependencies, using minimum supported versions
         run: |
-          min_versions=$(sed ${{ matrix.type }}/requirements.txt ${{ matrix.type }}/dev-requirements.txt -e 's/[~>]=\([0-9]\)/==\1/')
+          min_versions=$(sed -E 's/[~>]=([0-9]+(\.[0-9]+)*)(;.*)?/==\1/' ${{ matrix.type }}/requirements.txt ${{ matrix.type }}/dev-requirements.txt)
           python -m pip install --upgrade pip
           pip install ./checks-superstaq ${{ matrix.dependencies }} $min_versions
       - name: Coverage check

--- a/general-superstaq/requirements.txt
+++ b/general-superstaq/requirements.txt
@@ -1,4 +1,4 @@
-eval_type_backport>=0.2.2
+eval_type_backport>=0.2.2; python_version < '3.10'
 numpy>=1.21.0
 pydantic[email]>=2.6.0
 requests>=2.32.0


### PR DESCRIPTION
This PR makes `eval_type_backport` somewhat optional in the spirit of minimal package dependencies.

It also serves as a reminder to remove the requirement when Python 3.9 support is dropped. 