### PR TITLE
Add `AceCR` gate in integration tests

### DIFF
--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -29,6 +29,9 @@ def test_ibmq_compile(service: css.Service) -> None:
     circuit = cirq.Circuit(
         cirq.H(cirq.q(3)),
         cirq.CX(cirq.q(3), cirq.q(0)) ** 0.7,
+        css.AceCRMinusPlus(cirq.q(0), cirq.q(1)),
+        css.AceCRMinusPlus(cirq.q(1), cirq.q(2)),
+        css.AceCRMinusPlus(cirq.q(2), cirq.q(3)),
     )
 
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
@@ -53,6 +56,9 @@ def test_ibmq_compile_with_token() -> None:
     circuit = cirq.Circuit(
         cirq.H(cirq.q(3)),
         cirq.CX(cirq.q(3), cirq.q(0)) ** 0.7,
+        css.AceCRMinusPlus(cirq.q(0), cirq.q(1)),
+        css.AceCRMinusPlus(cirq.q(1), cirq.q(2)),
+        css.AceCRMinusPlus(cirq.q(2), cirq.q(3)),
     )
     out = service.ibmq_compile(circuit, target="ibmq_brisbane_qpu")
 

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -43,9 +43,12 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
 
 
 def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
-    qc = qiskit.QuantumCircuit(2)
+    qc = qiskit.QuantumCircuit(4)
     qc.h(0)
     qc.cx(0, 1)
+    qc.append(qss.AceCR("-+"), [0, 1])
+    qc.append(qss.AceCR("-+"), [1, 2])
+    qc.append(qss.AceCR("-+"), [2, 3])
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
     assert isinstance(out, qss.compiler_output.CompilerOutput)
@@ -68,9 +71,12 @@ def test_ibmq_compile(provider: qss.SuperstaqProvider) -> None:
 
 def test_ibmq_compile_with_token() -> None:
     provider = qss.SuperstaqProvider(ibmq_token=os.environ["TEST_USER_IBMQ_TOKEN"])
-    qc = qiskit.QuantumCircuit(2)
+    qc = qiskit.QuantumCircuit(4)
     qc.h(0)
     qc.cx(0, 1)
+    qc.append(qss.AceCR("-+"), [0, 1])
+    qc.append(qss.AceCR("-+"), [1, 2])
+    qc.append(qss.AceCR("-+"), [2, 3])
 
     out = provider.ibmq_compile(qc, target="ibmq_brisbane_qpu")
 


### PR DESCRIPTION
Fixes: https://github.com/Infleqtion/client-superstaq/issues/1170 by reverting https://github.com/Infleqtion/client-superstaq/pull/1174 & https://github.com/Infleqtion/client-superstaq/pull/1169