### PR TITLE
helper functions for qcvv protocols

### DIFF
--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment.py
@@ -433,6 +433,11 @@ class QCVVExperiment(ABC, Generic[ResultsT]):
         """The number of qubits used in the experiment."""
         return len(self.qubits)
 
+    @property
+    def circuits(self) -> list[cirq.Circuit]:
+        """All circuits in this experiment, as a list."""
+        return [sample.circuit for sample in self.samples]
+
     ###################
     # Private Methods #
     ###################

--- a/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/base_experiment_test.py
@@ -145,6 +145,7 @@ def test_qcvv_experiment_init(
     assert abc_experiment._service_kwargs == {"service_details": "Some other details"}
     assert len(abc_experiment.samples) == 30
     assert isinstance(abc_experiment._rng, np.random.Generator)
+    assert abc_experiment.circuits == [sample.circuit for sample in abc_experiment]
 
     new_experiment = ExampleExperiment(
         qubits=[cirq.q(1), cirq.q(3), cirq.q(7)],
@@ -153,6 +154,7 @@ def test_qcvv_experiment_init(
     )
     assert new_experiment.num_qubits == 3
     assert new_experiment.qubits == (cirq.q(1), cirq.q(3), cirq.q(7))
+    assert new_experiment.circuits == [sample.circuit for sample in new_experiment]
 
 
 def test_results_init(

--- a/supermarq-benchmarks/supermarq/qcvv/xeb.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb.py
@@ -435,6 +435,19 @@ class XEB(QCVVExperiment[XEBResults]):
             **kwargs,
         )
 
+    def independent_qubit_groups(self) -> list[tuple[cirq.Qid, ...]]:
+        """Get all independent subsets of qubits in this experiment.
+
+        Returns:
+            A list of disjoint tuples of `cirq.Qid` objects, each of which can be analyzed as an
+            independent XEB experiment.
+        """
+        if self.interleaved_layer:
+            qubit_sets = cirq.Circuit(self.interleaved_layer).get_independent_qubit_sets()
+            return sorted((tuple(sorted(qubit_set)) for qubit_set in qubit_sets), key=min)
+
+        return [self.qubits]
+
     ###################
     # Private Methods #
     ###################

--- a/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
+++ b/supermarq-benchmarks/supermarq/qcvv/xeb_test.py
@@ -357,6 +357,34 @@ def test_analytical_probabilities(
     )
 
 
+def test_independent_qubit_groups() -> None:
+    q0, q1, q2, q3 = cirq.LineQubit.range(4)
+
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=None)
+    assert experiment.independent_qubit_groups() == [(q0, q1)]
+
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=cirq.CZ)
+    assert experiment.independent_qubit_groups() == [(q0, q1)]
+
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=cirq.CCZ)
+    assert experiment.independent_qubit_groups() == [(q0, q1, q2)]
+
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=cirq.CZ(q1, q3))
+    assert experiment.independent_qubit_groups() == [(q1, q3)]
+
+    moment = cirq.Moment(cirq.X.on_each(q0, q2, q3))
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=moment)
+    assert experiment.independent_qubit_groups() == [(q0,), (q2,), (q3,)]
+
+    moment = cirq.Moment(cirq.CZ(q1, q3), cirq.CZ(q0, q2))
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=moment)
+    assert experiment.independent_qubit_groups() == [(q0, q2), (q1, q3)]
+
+    circuit = cirq.Circuit(cirq.CZ(q0, q1), cirq.CZ(q1, q2), cirq.X(q3))
+    experiment = XEB(num_circuits=3, cycle_depths=[1, 3], interleaved_layer=circuit)
+    assert experiment.independent_qubit_groups() == [(q0, q1, q2), (q3,)]
+
+
 def test_results_no_data() -> None:
     results = XEBResults(target="example", experiment=XEB(1, []), data=None)
     with pytest.raises(RuntimeError, match="No data stored. Cannot perform analysis."):


### PR DESCRIPTION
adds two convenience methods:
* `BaseExperiment.circuits` (a shortcut to `[sample.circuit for sample in experiment]`)
* `XEB.independent_qubit_groups()` (to get independent subgroups for parallel XEB)