### PR TITLE
Added warning attribute to `JobCancellationResults`

### DIFF
--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -187,7 +187,7 @@ class JobCancellationResults(DefaultPydanticModel):
     message: str
     """The server message."""
     warnings: list[str] 
-    """A warning that indicates a failed cancellation for a job that is already scheduled."""
+    """A warning that indicates a failed cancellation for a job that already has a status."""
 
 
 class NewJobResponse(DefaultPydanticModel):

--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -186,6 +186,8 @@ class JobCancellationResults(DefaultPydanticModel):
     """List of circuits that successfully cancelled."""
     message: str
     """The server message."""
+    warnings: list[str] 
+    """A warning that indicates a failed cancellation for a job that is already scheduled."""
 
 
 class NewJobResponse(DefaultPydanticModel):

--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -186,7 +186,7 @@ class JobCancellationResults(DefaultPydanticModel):
     """List of circuits that successfully cancelled."""
     message: str
     """The server message."""
-    warnings: list[str] 
+    warnings: list[str]
     """A warning that indicates a failed cancellation for a job that already has a status."""
 
 

--- a/general-superstaq/general_superstaq/_models.py
+++ b/general-superstaq/general_superstaq/_models.py
@@ -186,7 +186,7 @@ class JobCancellationResults(DefaultPydanticModel):
     """List of circuits that successfully cancelled."""
     message: str
     """The server message."""
-    warnings: list[str]
+    warnings: list[dict]
     """A warning that indicates a failed cancellation for a job that already has a status."""
 
 

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -1192,6 +1192,7 @@ def test_superstaq_client_cancel_jobs_retry(
         response2.json.return_value = {
             "succeeded": [str(job_id)],
             "message": "",
+            "warnings": [{"message": ""}]
         }
 
     with mock.patch(call_type) as mock_call:


### PR DESCRIPTION
This is to fix a server-side issue for today's deploy: a server-side test expects `JobCancellationResults` to have a `warnings` attribute for catching a failed attempted at cancelling a job that already has a status.