### PR TITLE
Upper bound notebook `pytest` threads to 4

### DIFF
--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -89,7 +89,7 @@ def run(
     if parsed_args.notebook:
         # These tests spend most of their time waiting for the server, so allow more threads than we
         # have physical processors (within reason)
-        nthreads = min(len(files), 16)
+        nthreads = min(len(files), 4)
         nthreads = 0 if nthreads <= 1 else nthreads
 
         # Setting before other args so -n can be overwritten


### PR DESCRIPTION
Various notebook check timeouts/failures, like in https://github.com/Infleqtion/client-superstaq/issues/1129, may potentially be attributed to spawning too many kernels in a short amount of time, trying to use a port already in use. This PR hence limits the number of threads to a maximum of four in an effort to reduce the likelihood of such scenarios from happening.

As of this PR, the number of workers currently spawned by each notebook check is:

- `cirq-superstaq`: 9 workers
- `qiskit-superstaq:` 8 workers
- `supermarq-benchmarks`: 6 workers