### PR TITLE
Use variable `num_qubits` in `cirq` daily integration test

### DIFF
--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -358,9 +358,9 @@ def test_dry_run_submit_to_sqale_with_qubit_sorting(service: css.Service) -> Non
     num_qubits = service.target_info(target)["num_qubits"]
     qubits = cirq.LineQubit.range(num_qubits)
     circuit = cirq.Circuit(
-        css.ParallelRGate(np.pi / 2, 0.0, 24).on(*qubits),
+        css.ParallelRGate(np.pi / 2, 0.0, num_qubits).on(*qubits),
         cirq.rz(np.pi).on(qubits[2]),
-        css.ParallelRGate(-np.pi / 2, 0.0, 24).on(*qubits),
+        css.ParallelRGate(-np.pi / 2, 0.0, num_qubits).on(*qubits),
         cirq.measure(*qubits),
     )
 


### PR DESCRIPTION
Fixes: https://github.com/Infleqtion/client-superstaq/issues/1259