### PR TITLE
drop unintentional whitespace chars in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@
     <img
       alt="License"
       src="https://img.shields.io/github/license/Infleqtion/client-superstaq?style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 <a href="https://github.com/Infleqtion/client-superstaq">
   <picture>
     <!-- dark -->
@@ -40,9 +38,7 @@
     <img
       alt="Python Versions"
       src="https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14%20-141a5e?display_name=tag&style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 <a href="https://github.com/Infleqtion/client-superstaq/releases">
   <picture>
     <!-- dark -->
@@ -59,9 +55,7 @@
     <img
       alt="GitHub Release"
       src="https://img.shields.io/github/v/release/Infleqtion/client-superstaq?display_name=tag&style=flat&logo=pypi&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 <a href="https://github.com/Infleqtion/client-superstaq/actions/workflows/ci.yml">
   <picture>
     <!-- dark -->
@@ -78,9 +72,7 @@
     <img
       alt="CI Status"
       src="https://img.shields.io/github/actions/workflow/status/Infleqtion/client-superstaq/ci.yml?branch=main&style=flat&logo=github&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 <a href="https://join.slack.com/t/superstaq/shared_invite/zt-1wr6eok5j-fMwB7dPEWGG~5S474xGhxw">
   <picture>
     <!-- dark -->
@@ -97,9 +89,7 @@
     <img
       alt="Slack"
       src="https://img.shields.io/badge/Slack-slack?style=flat&logo=slack&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 <a href="https://superstaq.readthedocs.io/">
   <picture>
     <!-- dark -->
@@ -116,9 +106,7 @@
     <img
       alt="Read the Docs"
       src="https://img.shields.io/badge/Read%20the%20docs-a?style=flat&logo=read-the-docs&logoColor=white&labelColor=00b198&color=141a5e"
-    />
-  </picture>
-</a>
+    /></picture></a>
 </div>
 
 # Welcome to Superstaq


### PR DESCRIPTION
before: 
<img width="744" height="64" alt="image" src="https://github.com/user-attachments/assets/57ea45dc-f173-4dac-9b30-9ec88ece1088" />
after: 
<img width="745" height="70" alt="image" src="https://github.com/user-attachments/assets/5828fb70-1ee7-4789-95d6-ef3e38f262db" />

also changes file format from dos to unix, which is causing the large diff. The only real change is the removal of newlines in instances of
```
    />
  </picture>
</a>
```
which are now just
```
    /></picture></a>
```