### PR TITLE
skip warning when missing test files for `__init__.py` and `conftest.py`

### DIFF
--- a/checks-superstaq/checks_superstaq/check_utils.py
+++ b/checks-superstaq/checks_superstaq/check_utils.py
@@ -272,7 +272,7 @@ def get_test_files(
         ):
             test_files.append(test_file)
 
-        elif not silent:
+        elif not silent and basename not in ("__init__.py", "conftest.py"):
             print(warning(f"WARNING: no test file found for {file}"))  # noqa: T201
 
     if exclude:


### PR DESCRIPTION
by default running the pytest/coverage checks prints warnings for missing test files, e.g.
```
...
WARNING: no test file found for cirq-superstaq/cirq_superstaq/__init__.py
WARNING: no test file found for cirq-superstaq/cirq_superstaq/circuits/__init__.py
WARNING: no test file found for cirq-superstaq/cirq_superstaq/ops/__init__.py
WARNING: no test file found for cirq-superstaq/cirq_superstaq/sampler.py
...
```
this is fine for standard modules, but files like `__init__.py` and `conftest.py` are not expected to have their own test files and so shouldn't produce a warning