### PR TITLE
update readme gif

### DIFF
--- a/docs/source/_static/svg/code.svg
+++ b/docs/source/_static/svg/code.svg
@@ -201,7 +201,7 @@
             <span class="line-02"><span class="c-m">import</span> qiskit_superstaq <span class="c-m">as</span> qss</span></p>
 
             <p><span class="line-03">superstaq = qss.<span class="c-o">SuperstaqProvider</span>()</span><br/>
-            <span class="line-04">backend = superstaq.<span class="c-o">get_backend</span>("sqale_boulder_qpu")</span></p>
+            <span class="line-04">backend = superstaq.<span class="c-o">get_backend</span>("cq_sqale_qpu")</span></p>
 
             <p><span class="line-05"><span class="c-c"># Standard bell circuit</span></span><br/>
             <span class="line-06">qc = qiskit.<span class="c-m">QuantumCircuit</span>(2, 2)</span><br/>


### PR DESCRIPTION
[noting that you can open the "gif" svg file as text to edit - the graphic is just composed of the underlying text]

updated readme gif:
* colors to match infleqtion color scheme
* backend name to `sqale_boulder_qpu`