### PR TITLE
Call sys.executable instead of python directly

### DIFF
--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -150,7 +150,7 @@ def _run_on_files(
 
     test_returncode = subprocess.call(
         [
-            "python",
+            sys.executable,
             "-m",
             "coverage",
             "run",
@@ -167,13 +167,13 @@ def _run_on_files(
 
 def _report(test_returncode: int) -> int:
     subprocess.call(
-        ["python", "-m", "coverage", "combine"],
+        [sys.executable, "-m", "coverage", "combine"],
         cwd=check_utils.root_dir,
         stdout=subprocess.DEVNULL,
     )
 
     coverage_returncode = subprocess.call(
-        ["python", "-m", "coverage", "report", "--precision=2"],
+        [sys.executable, "-m", "coverage", "report", "--precision=2"],
         cwd=check_utils.root_dir,
     )
 

--- a/checks-superstaq/checks_superstaq/format_.py
+++ b/checks-superstaq/checks_superstaq/format_.py
@@ -64,7 +64,8 @@ def run(
 
     if files:
         returncode_ruff_format = subprocess.call(
-            ["python", "-m", "ruff", "format", *files, *args_to_pass], cwd=check_utils.root_dir
+            [sys.executable, "-m", "ruff", "format", *files, *args_to_pass],
+            cwd=check_utils.root_dir,
         )
         if returncode_ruff_format == 1:
             command = "./checks/format_.py --fix"

--- a/checks-superstaq/checks_superstaq/lint_.py
+++ b/checks-superstaq/checks_superstaq/lint_.py
@@ -60,7 +60,7 @@ def run(
 
     if files:
         return subprocess.call(
-            ["python", "-m", "ruff", "check", *files, *args_to_pass], cwd=check_utils.root_dir
+            [sys.executable, "-m", "ruff", "check", *files, *args_to_pass], cwd=check_utils.root_dir
         )
 
     return 0

--- a/checks-superstaq/checks_superstaq/mypy_.py
+++ b/checks-superstaq/checks_superstaq/mypy_.py
@@ -56,7 +56,7 @@ def run(
     files = check_utils.extract_files(parsed_args, include, exclude, silent)
 
     return subprocess.call(
-        ["python", "-m", "mypy", *files, *args_to_pass], cwd=check_utils.root_dir
+        [sys.executable, "-m", "mypy", *files, *args_to_pass], cwd=check_utils.root_dir
     )
 
 

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -129,7 +129,7 @@ def run(
         integration_setup()
 
     return subprocess.call(
-        ["python", "-m", "pytest", *files, *args_to_pass],
+        [sys.executable, "-m", "pytest", *files, *args_to_pass],
         cwd=check_utils.root_dir,
     )
 


### PR DESCRIPTION
This should be more robust to virtual environment confusions.