### PR TITLE
Revert `pytest-split` usage for CI notebook checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,28 +223,13 @@ jobs:
           - type: "qiskit-superstaq"
             pattern: "'*_qss.ipynb' qiskit-superstaq -x 'docs/source/apps/*'"
             dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq[examples] -e ./cirq-superstaq"
-            group: 1
           - type: "cirq-superstaq"
             pattern: "'*_css.ipynb' cirq-superstaq -x 'docs/source/apps/*'"
             dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq -e ./cirq-superstaq[examples]"
-            group: 1
           - type: "supermarq"
             pattern: "docs/source/apps/supermarq"
             dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq -e ./cirq-superstaq -e ./supermarq-benchmarks"
-            group: 1
-          - type: "qiskit-superstaq"
-            pattern: "'*_qss.ipynb' qiskit-superstaq -x 'docs/source/apps/*'"
-            dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq[examples] -e ./cirq-superstaq"
-            group: 2
-          - type: "cirq-superstaq"
-            pattern: "'*_css.ipynb' cirq-superstaq -x 'docs/source/apps/*'"
-            dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq -e ./cirq-superstaq[examples]"
-            group: 2
-          - type: "supermarq"
-            pattern: "docs/source/apps/supermarq"
-            dependencies: "-e ./checks-superstaq -e ./general-superstaq -e ./qiskit-superstaq -e ./cirq-superstaq -e ./supermarq-benchmarks"
-            group: 2
-    name: Notebook check for ${{ matrix.type }} (${{ matrix.group }}/2)
+    name: Notebook check for ${{ matrix.type }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 3.14
@@ -258,7 +243,7 @@ jobs:
       - name: Check notebooks
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          checks/pytest_.py --notebook ${{ matrix.pattern }} --splits=2 --group=${{ matrix.group }} -v
+          checks/pytest_.py --notebook ${{ matrix.pattern }} -v
 
   docs:
     name: Build docs


### PR DESCRIPTION
https://github.com/Infleqtion/client-superstaq/pull/1360 added usage of `pytest-split` to the CI's notebook checks in hopes of mitigating against https://github.com/Infleqtion/client-superstaq/issues/1129. However, this has been falsified by a [notebook check flake](https://github.com/Infleqtion/client-superstaq/actions/runs/24104137963/job/70322973623) occurring regardless. As such, the PR reverts some of the changes introduced in https://github.com/Infleqtion/client-superstaq/pull/1360 to reduce redundant CI minute usage for apparent minimal benefit (at this point at least)