### PR TITLE
Update Superstaq target assertion in daily integration tests (+ workflow updates)

### DIFF
--- a/.github/integration-check-failure-issue.md
+++ b/.github/integration-check-failure-issue.md
@@ -2,3 +2,7 @@
 title: Integration test failed
 labels: reminder
 ---
+
+Daily integration check has failed. See the associated workflow below:
+
+- Workflow run: {{ env.RUN_URL }}

--- a/.github/workflows/daily-integration-check.yml
+++ b/.github/workflows/daily-integration-check.yml
@@ -19,12 +19,12 @@ jobs:
                     - type: "qiskit-superstaq"
                       dependencies: "./checks-superstaq ./qiskit-superstaq"
                       group: 1
-                    - type: "cirq-superstaq"
-                      dependencies: "./checks-superstaq ./qiskit-superstaq ./cirq-superstaq"
-                      group: 1
                     - type: "qiskit-superstaq"
                       dependencies: "./checks-superstaq ./qiskit-superstaq"
                       group: 2
+                    - type: "cirq-superstaq"
+                      dependencies: "./checks-superstaq ./qiskit-superstaq ./cirq-superstaq"
+                      group: 1
                     - type: "cirq-superstaq"
                       dependencies: "./checks-superstaq ./qiskit-superstaq ./cirq-superstaq"
                       group: 2
@@ -42,12 +42,20 @@ jobs:
                   python -m pip install ${{ matrix.dependencies }}
             - name: Pytest integration check (group ${{ matrix.group }} of 2)
               run: |
-                  checks/pytest_.py --integration --splits=2 --group=${{ matrix.group }} -v ${{ matrix.type }}
-            - name: Create issue if integration check failed
-              if: ${{ failure() }}
+                  checks/pytest_.py -n=4 --integration --splits=2 --group=${{ matrix.group }} -v ${{ matrix.type }}
+
+    create-issue-if-integration-check-failed:
+        name: Create issue if scheduled integration check failed
+        needs: daily-integration-check
+        if: ${{ always() && github.event_name == 'schedule' && needs.daily-integration-check.result == 'failure' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Create issue
               uses: JasonEtco/create-an-issue@v2
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               with:
                   filename: .github/integration-check-failure-issue.md
                   update_existing: true

--- a/cirq-superstaq/cirq_superstaq/daily_integration_test.py
+++ b/cirq-superstaq/cirq_superstaq/daily_integration_test.py
@@ -191,20 +191,16 @@ def test_get_targets(service: css.Service) -> None:
         accessible=False,
     )
 
-    assert ibmq_target_info in result
-    assert aqt_target_info in result
-
     unfiltered_targets = {t.target: t for t in result}
+    assert aqt_target_info in result
+    assert ibmq_target_info.target in unfiltered_targets
+
     for target in filtered_result:
         assert target.target in unfiltered_targets, f"'{target.target}' not in unfiltered result"
-        assert target == unfiltered_targets[target.target], (
-            f"Divergent targets.\nFiltered: {target!r}\n"
-            f"Unfiltered: {unfiltered_targets[target.target]!r}"
-        )
 
     for gss_target in result:
         target_name = gss_target.target
-        assert service.target_info(target_name)["target"] == target_name
+        assert service.target_info(target_name).get("target") == target_name
 
 
 def test_qscout_compile(service: css.Service) -> None:

--- a/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/daily_integration_test.py
@@ -48,22 +48,19 @@ def test_backends(provider: qss.SuperstaqProvider) -> None:
         retired=False,
         accessible=True,
     )
-    assert ibmq_backend_info in result
 
     unfiltered_targets = {t.target: t for t in result}
+    assert ibmq_backend_info.target in unfiltered_targets
+
     for target in filtered_result:
         assert target.target in unfiltered_targets, f"'{target.target}' not in unfiltered result"
-        assert target == unfiltered_targets[target.target], (
-            f"Divergent targets.\nFiltered: {target!r}\n"
-            f"Unfiltered: {unfiltered_targets[target.target]!r}"
-        )
 
     backends = provider.backends()
     for backend in backends:
         assert backend.name in unfiltered_targets, (
             f"'{backend.name}' included in `backends()` but not `get_targets()`"
         )
-        assert backend.target_info()["target"] == backend.name
+        assert backend.target_info().get("target") == backend.name
         assert backend.target.num_qubits is not None
 
     missing_backends = unfiltered_targets.keys() - {backend.name for backend in backends}


### PR DESCRIPTION
Closes: https://github.com/Infleqtion/client-superstaq/issues/1393

This PR makes the target assertion less strict due to dynamic fields like the target's availability. E.g., 
```bash
>           assert target == unfiltered_targets[target.target], (
                f"Divergent targets.\nFiltered: {target!r}\n"
                f"Unfiltered: {unfiltered_targets[target.target]!r}"
            )
E           AssertionError: Divergent targets.
E             Filtered: Target(target='qtm_helios-1_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=False, retired=False, accessible=True)
E             Unfiltered: Target(target='qtm_helios-1_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False, accessible=True)
E           assert Target(target...cessible=True) == Target(target...cessible=True)
E             
E             Full diff:
E             - Target(target='qtm_helios-1_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=True, retired=False, accessible=True)
E             ?                                                                                                                      ^^^
E             + Target(target='qtm_helios-1_qpu', supports_submit=True, supports_submit_qubo=False, supports_compile=True, available=False, retired=False, accessible=True)
E             ?    
```


This PR also makes it so the issue creation job does not trigger for manually dispatched workflows and also makes the job a dependent, separate job to ensure multiple issues aren't created for each failed sub-workflow in the matrix strategy.