### PR TITLE
Update some typing for `requests>=2.34.2` & use `http.HTTPStatus` for status codes everywhere

### DIFF
--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -28,6 +28,7 @@
 from __future__ import annotations
 
 import datetime
+import http
 import json
 import textwrap
 import uuid
@@ -190,7 +191,7 @@ def multi_circuit_job() -> css.Job:
 
 def _mocked_request_response(content: object) -> requests.Response:
     response = requests.Response()
-    response.status_code = requests.codes.OK
+    response.status_code = http.HTTPStatus.OK.value
     response._content = json.dumps(content).encode()
     return response
 

--- a/cirq-superstaq/cirq_superstaq/worker_test.py
+++ b/cirq-superstaq/cirq_superstaq/worker_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import http
 import uuid
 from unittest import mock
 
@@ -41,11 +42,11 @@ def test_get_next_task(mock_get: mock.MagicMock) -> None:
     )
 
     response1 = requests.Response()
-    response1.status_code = requests.codes.ok
+    response1.status_code = http.HTTPStatus.OK.value
     response1._content = worker_task.model_dump_json().encode()
 
     response2 = requests.Response()
-    response2.status_code = requests.codes.ok
+    response2.status_code = http.HTTPStatus.OK.value
     response2._content = b"null"
 
     mock_get.side_effect = [response1, response2, response2]
@@ -73,7 +74,7 @@ def test_get_task_status(mock_get: mock.MagicMock) -> None:
     )
 
     mock_get.return_value = requests.Response()
-    mock_get.return_value.status_code = requests.codes.ok
+    mock_get.return_value.status_code = http.HTTPStatus.OK.value
     mock_get.return_value._content = worker_task_status.model_dump_json().encode()
 
     status = worker.get_task_status(task_id)

--- a/general-superstaq/general_superstaq/job_test.py
+++ b/general-superstaq/general_superstaq/job_test.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import datetime
+import http
 import json
 import textwrap
 import uuid
@@ -71,7 +72,7 @@ def _job_dict() -> dict[str, object]:
 
 def _mocked_response(content: object) -> requests.Response:
     response = requests.Response()
-    response.status_code = requests.codes.OK
+    response.status_code = http.HTTPStatus.OK.value
     response._content = json.dumps(content).encode()
     return response
 

--- a/general-superstaq/general_superstaq/machine_api_test.py
+++ b/general-superstaq/general_superstaq/machine_api_test.py
@@ -55,7 +55,7 @@ def test_unaccepted_terms_of_use(mock_get: mock.MagicMock) -> None:
     machine_api = MachineAPI("machine_api", api_key="token")
 
     mock_get.return_value = requests.Response()
-    mock_get.return_value.status_code = requests.codes.unauthorized
+    mock_get.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
     mock_get.return_value._content = (
         b'"You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."'
     )

--- a/general-superstaq/general_superstaq/machine_api_test.py
+++ b/general-superstaq/general_superstaq/machine_api_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import http
 import uuid
 from unittest import mock
 
@@ -31,11 +32,11 @@ def test_get_next_task(mock_get: mock.MagicMock) -> None:
     worker_task = gss.models.WorkerTask(circuit_ref=task_id, circuit='["circuit"]', shots=10)
 
     response1 = requests.Response()
-    response1.status_code = requests.codes.ok
+    response1.status_code = http.HTTPStatus.OK.value
     response1._content = worker_task.model_dump_json().encode()
 
     response2 = requests.Response()
-    response2.status_code = requests.codes.ok
+    response2.status_code = http.HTTPStatus.OK.value
     response2._content = b"null"
 
     mock_get.side_effect = [response1, response2, response2]
@@ -75,7 +76,7 @@ def test_get_task_status(mock_get: mock.MagicMock) -> None:
     )
 
     mock_get.return_value = requests.Response()
-    mock_get.return_value.status_code = requests.codes.ok
+    mock_get.return_value.status_code = http.HTTPStatus.OK.value
     mock_get.return_value._content = worker_task_status.model_dump_json().encode()
 
     status = machine_api.get_task_status(task_id)

--- a/general-superstaq/general_superstaq/machine_api_test.py
+++ b/general-superstaq/general_superstaq/machine_api_test.py
@@ -56,7 +56,7 @@ def test_unaccepted_terms_of_use(mock_get: mock.MagicMock) -> None:
     machine_api = MachineAPI("machine_api", api_key="token")
 
     mock_get.return_value = requests.Response()
-    mock_get.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+    mock_get.return_value.status_code = requests.codes.unauthorized
     mock_get.return_value._content = (
         b'"You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."'
     )

--- a/general-superstaq/general_superstaq/machine_api_test.py
+++ b/general-superstaq/general_superstaq/machine_api_test.py
@@ -56,7 +56,7 @@ def test_unaccepted_terms_of_use(mock_get: mock.MagicMock) -> None:
     machine_api = MachineAPI("machine_api", api_key="token")
 
     mock_get.return_value = requests.Response()
-    mock_get.return_value.status_code = requests.codes.unauthorized
+    mock_get.return_value.status_code = http.HTTPStatus.UNAUTHORIZED.value
     mock_get.return_value._content = (
         b'"You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."'
     )

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -260,7 +260,7 @@ class _BaseSuperstaqClient:
             ~gss.SuperstaqServerException: If an error has occurred in making a request
                 to the Superstaq API.
         """
-        if response.status_code == requests.codes.unauthorized:
+        if response.status_code == http.HTTPStatus.UNAUTHORIZED.value:
             if response.json() == (
                 "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
             ):
@@ -279,7 +279,7 @@ class _BaseSuperstaqClient:
                 response.status_code,
             )
 
-        if response.status_code == requests.codes.gateway_timeout:
+        if response.status_code == http.HTTPStatus.GATEWAY_TIMEOUT.value:
             # Job took too long. Don't retry, it probably won't be any faster.
             raise gss.SuperstaqServerException(
                 "Connection timed out while processing your request. Try submitting a smaller "

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -40,7 +40,7 @@ import urllib
 import uuid
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
 
 import numpy as np
@@ -344,7 +344,7 @@ class _BaseSuperstaqClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    def _custom_headers(self, **credentials: str) -> Mapping[str, str | bytes]:
+    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str | bytes]:
         custom_headers: dict[str, str | bytes] = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import copy
 import enum
+import http
 import json
 import os
 import pathlib
@@ -70,7 +71,7 @@ class _BaseSuperstaqClient:
     """
 
     RETRIABLE_STATUS_CODES: ClassVar[set[int]] = {
-        requests.codes.service_unavailable,
+        http.HTTPStatus.SERVICE_UNAVAILABLE.value,
     }
     SUPPORTED_VERSIONS: ClassVar[set[str]] = {v.value for v in ApiVersion}
 
@@ -184,9 +185,7 @@ class _BaseSuperstaqClient:
         response = self._make_request(request)
         return self._handle_response(response)
 
-    def post_request(
-        self, endpoint: str, json_dict: Mapping[str, object], **credentials: str
-    ) -> Any:
+    def post_request(self, endpoint: str, json_dict: Mapping[str, Any], **credentials: str) -> Any:
         """Performs a POST request on a given endpoint with a given payload.
 
         Args:
@@ -214,9 +213,7 @@ class _BaseSuperstaqClient:
         response = self._make_request(request)
         return self._handle_response(response)
 
-    def put_request(
-        self, endpoint: str, json_dict: Mapping[str, object], **credentials: str
-    ) -> Any:
+    def put_request(self, endpoint: str, json_dict: Mapping[str, Any], **credentials: str) -> Any:
         """Performs a PUT request on a given endpoint with a given payload.
 
         Args:
@@ -364,7 +361,7 @@ class _BaseSuperstaqClient:
         """
         raise gss.SuperstaqServerException(
             "You'll need to accept the Terms of Use before usage of Superstaq.",
-            requests.codes.unauthorized,
+            http.HTTPStatus.UNAUTHORIZED.value,
         )
 
     @staticmethod
@@ -963,7 +960,7 @@ class _AbstractUserClient(_BaseSuperstaqClient, ABC):
         if response != "Accepted. You can now continue using Superstaq.":
             raise gss.SuperstaqServerException(
                 "You'll need to accept the Terms of Use before usage of Superstaq.",
-                requests.codes.unauthorized,
+                http.HTTPStatus.UNAUTHORIZED.value,
             )
 
     @staticmethod

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -54,10 +54,6 @@ if TYPE_CHECKING:
 RECOGNISED_CIRCUIT_TYPES = Literal[gss.models.CircuitType.CIRQ, gss.models.CircuitType.QISKIT]
 """The circuit types that are currently implemented within the `SuperstaqClient`."""
 
-HTTP_UNAUTHORIZED: int = int(requests.codes.unauthorized)
-HTTP_SERVICE_UNAVAILABLE: int = int(requests.codes.service_unavailable)
-HTTP_GATEWAY_TIMEOUT: int = int(requests.codes.gateway_timeout)
-
 
 class ApiVersion(str, enum.Enum):
     """The supported API versions."""
@@ -74,7 +70,7 @@ class _BaseSuperstaqClient:
     """
 
     RETRIABLE_STATUS_CODES: ClassVar[set[int]] = {
-        HTTP_SERVICE_UNAVAILABLE,
+        requests.codes.service_unavailable,
     }
     SUPPORTED_VERSIONS: ClassVar[set[str]] = {v.value for v in ApiVersion}
 
@@ -268,7 +264,7 @@ class _BaseSuperstaqClient:
             ~gss.SuperstaqServerException: If an error has occurred in making a request
                 to the Superstaq API.
         """
-        if response.status_code == HTTP_UNAUTHORIZED:
+        if response.status_code == requests.codes.unauthorized:
             if response.json() == (
                 "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
             ):
@@ -287,7 +283,7 @@ class _BaseSuperstaqClient:
                 response.status_code,
             )
 
-        if response.status_code == HTTP_GATEWAY_TIMEOUT:
+        if response.status_code == requests.codes.gateway_timeout:
             # Job took too long. Don't retry, it probably won't be any faster.
             raise gss.SuperstaqServerException(
                 "Connection timed out while processing your request. Try submitting a smaller "
@@ -368,7 +364,7 @@ class _BaseSuperstaqClient:
         """
         raise gss.SuperstaqServerException(
             "You'll need to accept the Terms of Use before usage of Superstaq.",
-            HTTP_UNAUTHORIZED,
+            requests.codes.unauthorized,
         )
 
     @staticmethod
@@ -967,7 +963,7 @@ class _AbstractUserClient(_BaseSuperstaqClient, ABC):
         if response != "Accepted. You can now continue using Superstaq.":
             raise gss.SuperstaqServerException(
                 "You'll need to accept the Terms of Use before usage of Superstaq.",
-                HTTP_UNAUTHORIZED,
+                requests.codes.unauthorized,
             )
 
     @staticmethod

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -344,8 +344,8 @@ class _BaseSuperstaqClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str]:
-        custom_headers: dict[str, str] = dict(self.headers)
+    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str | bytes]:
+        custom_headers: dict[str, str | bytes] = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:
                 custom_headers[key] = credentials[key]

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -28,7 +28,6 @@
 
 from __future__ import annotations
 
-import copy
 import enum
 import http
 import json
@@ -41,7 +40,7 @@ import urllib
 import uuid
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
 
 import numpy as np
@@ -345,8 +344,8 @@ class _BaseSuperstaqClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    def _custom_headers(self, **credentials: str) -> dict[str, str]:
-        custom_headers = dict(self.headers)
+    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str | bytes]:
+        custom_headers: dict[str, str | bytes] = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:
                 custom_headers[key] = credentials[key]

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -40,7 +40,7 @@ import urllib
 import uuid
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NoReturn
 
 import numpy as np
@@ -344,7 +344,7 @@ class _BaseSuperstaqClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str | bytes]:
+    def _custom_headers(self, **credentials: str) -> Mapping[str, str | bytes]:
         custom_headers: dict[str, str | bytes] = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -344,8 +344,8 @@ class _BaseSuperstaqClient:
             time.sleep(delay_seconds)
             delay_seconds *= 2
 
-    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str | bytes]:
-        custom_headers: dict[str, str | bytes] = dict(self.headers)
+    def _custom_headers(self, **credentials: str) -> MutableMapping[str, str]:
+        custom_headers: dict[str, str] = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:
                 custom_headers[key] = credentials[key]

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -54,6 +54,10 @@ if TYPE_CHECKING:
 RECOGNISED_CIRCUIT_TYPES = Literal[gss.models.CircuitType.CIRQ, gss.models.CircuitType.QISKIT]
 """The circuit types that are currently implemented within the `SuperstaqClient`."""
 
+HTTP_UNAUTHORIZED: int = int(requests.codes.unauthorized)
+HTTP_SERVICE_UNAVAILABLE: int = int(requests.codes.service_unavailable)
+HTTP_GATEWAY_TIMEOUT: int = int(requests.codes.gateway_timeout)
+
 
 class ApiVersion(str, enum.Enum):
     """The supported API versions."""
@@ -70,7 +74,7 @@ class _BaseSuperstaqClient:
     """
 
     RETRIABLE_STATUS_CODES: ClassVar[set[int]] = {
-        requests.codes.service_unavailable,
+        HTTP_SERVICE_UNAVAILABLE,
     }
     SUPPORTED_VERSIONS: ClassVar[set[str]] = {v.value for v in ApiVersion}
 
@@ -264,7 +268,7 @@ class _BaseSuperstaqClient:
             ~gss.SuperstaqServerException: If an error has occurred in making a request
                 to the Superstaq API.
         """
-        if response.status_code == requests.codes.unauthorized:
+        if response.status_code == HTTP_UNAUTHORIZED:
             if response.json() == (
                 "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
             ):
@@ -283,7 +287,7 @@ class _BaseSuperstaqClient:
                 response.status_code,
             )
 
-        if response.status_code == requests.codes.gateway_timeout:
+        if response.status_code == HTTP_GATEWAY_TIMEOUT:
             # Job took too long. Don't retry, it probably won't be any faster.
             raise gss.SuperstaqServerException(
                 "Connection timed out while processing your request. Try submitting a smaller "
@@ -364,7 +368,7 @@ class _BaseSuperstaqClient:
         """
         raise gss.SuperstaqServerException(
             "You'll need to accept the Terms of Use before usage of Superstaq.",
-            requests.codes.unauthorized,
+            HTTP_UNAUTHORIZED,
         )
 
     @staticmethod
@@ -963,7 +967,7 @@ class _AbstractUserClient(_BaseSuperstaqClient, ABC):
         if response != "Accepted. You can now continue using Superstaq.":
             raise gss.SuperstaqServerException(
                 "You'll need to accept the Terms of Use before usage of Superstaq.",
-                requests.codes.unauthorized,
+                HTTP_UNAUTHORIZED,
             )
 
     @staticmethod

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -346,7 +346,7 @@ class _BaseSuperstaqClient:
             delay_seconds *= 2
 
     def _custom_headers(self, **credentials: str) -> dict[str, str]:
-        custom_headers = copy.deepcopy(self.headers)
+        custom_headers = dict(self.headers)
         for key in ["ibmq_token", "ibmq_instance", "ibmq_channel", "cq_token"]:
             if key in credentials:
                 custom_headers[key] = credentials[key]

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import http
 import io
 import json
 import os
@@ -414,7 +415,7 @@ def test_supertstaq_client_create_job(
     client = request.getfixturevalue(client_name)
     api_version = client.api_version
 
-    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.status_code = http.HTTPStatus.OK.value
     mock_post.return_value.json.return_value = {"job_id": job_id, "num_circuits": 1}
 
     response = client.create_job(
@@ -516,7 +517,7 @@ def test_superstaq_client_create_job_not_retriable(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.not_implemented
+    mock_post.return_value.status_code = http.HTTPStatus.NOT_IMPLEMENTED.value
 
     with pytest.raises(gss.SuperstaqServerException, match=r"Status code: 501"):
         _ = client.create_job({"cirq_circuits": "World"}, target="ss_example_qpu")
@@ -582,7 +583,7 @@ def test_superstaq_client_create_job_invalid_json(
     client = request.getfixturevalue(client_name)
 
     response = requests.Response()
-    response.status_code = requests.codes.not_implemented
+    response.status_code = http.HTTPStatus.NOT_IMPLEMENTED.value
     response._content = b"invalid/json"
     mock_post.return_value = response
 
@@ -2223,7 +2224,7 @@ def test_new_worker(
 ) -> None:
     token = secrets.token_hex(nbytes=32)
     mock_post.return_value = requests.Response()
-    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.status_code = http.HTTPStatus.OK.value
     mock_post.return_value._content = json.dumps({"worker_name": "worker", "token": token}).encode()
 
     target = "sqale_test_qpu"
@@ -2244,7 +2245,7 @@ def test_regenerate_worker_token(
     token = secrets.token_hex(nbytes=32)
 
     mock_post.return_value = requests.Response()
-    mock_post.return_value.status_code = requests.codes.ok
+    mock_post.return_value.status_code = http.HTTPStatus.OK.value
     mock_post.return_value._content = json.dumps(
         {"worker_name": "sqale_worker", "token": token}
     ).encode()

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -329,7 +329,7 @@ def test_superstaq_client_needs_accept_terms_of_use(
 
     fake_get_response = mock.MagicMock()
     fake_get_response.ok = False
-    fake_get_response.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+    fake_get_response.status_code = requests.codes.unauthorized
     fake_get_response.json.return_value = (
         "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
     )
@@ -366,7 +366,7 @@ def test_superstaq_client_validate_email_error(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+    mock_post.return_value.status_code = requests.codes.unauthorized
     mock_post.return_value.json.return_value = "You must validate your registered email."
 
     with pytest.raises(
@@ -485,7 +485,7 @@ def test_superstaq_client_create_job_unauthorized(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+    mock_post.return_value.status_code = requests.codes.unauthorized
 
     with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
         _ = client.create_job({"cirq_circuits": "World"}, target="ss_example_qpu")
@@ -539,7 +539,7 @@ def test_superstaq_client_create_job_retry(
         verbose=True,
     )
 
-    response1 = mock.MagicMock(ok=False, status_code=gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE)
+    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
     response1.json.return_value = {"job_id": job_id, "num_circuits": 1}
     response2 = mock.MagicMock(ok=True)
     response2.json.return_value = {"job_id": job_id, "num_circuits": 1}
@@ -604,7 +604,7 @@ def test_superstaq_client_create_job_dont_retry_on_timeout(
     client = request.getfixturevalue(client_name)
 
     response = requests.Response()
-    response.status_code = gss.superstaq_client.HTTP_GATEWAY_TIMEOUT
+    response.status_code = requests.codes.gateway_timeout
     response._content = b"invalid/json"
     mock_post.return_value = response
 
@@ -628,7 +628,7 @@ def test_superstaq_client_create_job_timeout(mock_post: mock.MagicMock, api_vers
     )
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE
+    mock_post.return_value.status_code = requests.codes.service_unavailable
 
     with pytest.raises(TimeoutError):
         _ = client.create_job({"qiskit_circuits": "World"}, target="ss_example_qpu")
@@ -1026,7 +1026,7 @@ def test_superstaq_client_fetch_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+        mock_call.return_value.status_code = requests.codes.unauthorized
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.fetch_jobs([job_id])
@@ -1095,7 +1095,7 @@ def test_superstaq_client_fetch_jobs_retry(
 
     response1 = mock.MagicMock()
     response1.ok = False
-    response1.status_code = gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE
+    response1.status_code = requests.codes.service_unavailable
 
     response2 = mock.MagicMock()
     response2.ok = True
@@ -1124,7 +1124,7 @@ def test_superstaq_client_cancel_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
+        mock_call.return_value.status_code = requests.codes.unauthorized
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.cancel_jobs([job_id])
@@ -1191,7 +1191,7 @@ def test_superstaq_client_cancel_jobs_retry(
 ) -> None:
     client = request.getfixturevalue(client_name)
 
-    response1 = mock.MagicMock(ok=False, status_code=gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE)
+    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
     response2 = mock.MagicMock(ok=True)
     if client.api_version == "v0.3.0":
         response2.json.return_value = {

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -328,7 +328,7 @@ def test_superstaq_client_needs_accept_terms_of_use(
 
     fake_get_response = mock.MagicMock()
     fake_get_response.ok = False
-    fake_get_response.status_code = requests.codes.unauthorized
+    fake_get_response.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
     fake_get_response.json.return_value = (
         "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
     )
@@ -365,7 +365,7 @@ def test_superstaq_client_validate_email_error(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.unauthorized
+    mock_post.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
     mock_post.return_value.json.return_value = "You must validate your registered email."
 
     with pytest.raises(
@@ -484,7 +484,7 @@ def test_superstaq_client_create_job_unauthorized(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.unauthorized
+    mock_post.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
 
     with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
         _ = client.create_job({"cirq_circuits": "World"}, target="ss_example_qpu")
@@ -538,7 +538,7 @@ def test_superstaq_client_create_job_retry(
         verbose=True,
     )
 
-    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
+    response1 = mock.MagicMock(ok=False, status_code=gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE)
     response1.json.return_value = {"job_id": job_id, "num_circuits": 1}
     response2 = mock.MagicMock(ok=True)
     response2.json.return_value = {"job_id": job_id, "num_circuits": 1}
@@ -603,7 +603,7 @@ def test_superstaq_client_create_job_dont_retry_on_timeout(
     client = request.getfixturevalue(client_name)
 
     response = requests.Response()
-    response.status_code = requests.codes.gateway_timeout
+    response.status_code = gss.superstaq_client.HTTP_GATEWAY_TIMEOUT
     response._content = b"invalid/json"
     mock_post.return_value = response
 
@@ -627,7 +627,7 @@ def test_superstaq_client_create_job_timeout(mock_post: mock.MagicMock, api_vers
     )
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.service_unavailable
+    mock_post.return_value.status_code = gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE
 
     with pytest.raises(TimeoutError):
         _ = client.create_job({"qiskit_circuits": "World"}, target="ss_example_qpu")
@@ -1025,7 +1025,7 @@ def test_superstaq_client_fetch_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.unauthorized
+        mock_call.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.fetch_jobs([job_id])
@@ -1094,7 +1094,7 @@ def test_superstaq_client_fetch_jobs_retry(
 
     response1 = mock.MagicMock()
     response1.ok = False
-    response1.status_code = requests.codes.service_unavailable
+    response1.status_code = gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE
 
     response2 = mock.MagicMock()
     response2.ok = True
@@ -1123,7 +1123,7 @@ def test_superstaq_client_cancel_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.unauthorized
+        mock_call.return_value.status_code = gss.superstaq_client.HTTP_UNAUTHORIZED
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.cancel_jobs([job_id])
@@ -1190,7 +1190,7 @@ def test_superstaq_client_cancel_jobs_retry(
 ) -> None:
     client = request.getfixturevalue(client_name)
 
-    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
+    response1 = mock.MagicMock(ok=False, status_code=gss.superstaq_client.HTTP_SERVICE_UNAVAILABLE)
     response2 = mock.MagicMock(ok=True)
     if client.api_version == "v0.3.0":
         response2.json.return_value = {

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -604,7 +604,7 @@ def test_superstaq_client_create_job_dont_retry_on_timeout(
     client = request.getfixturevalue(client_name)
 
     response = requests.Response()
-    response.status_code = requests.codes.gateway_timeout
+    response.status_code = http.HTTPStatus.GATEWAY_TIMEOUT.value
     response._content = b"invalid/json"
     mock_post.return_value = response
 

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -329,7 +329,7 @@ def test_superstaq_client_needs_accept_terms_of_use(
 
     fake_get_response = mock.MagicMock()
     fake_get_response.ok = False
-    fake_get_response.status_code = requests.codes.unauthorized
+    fake_get_response.status_code = http.HTTPStatus.UNAUTHORIZED.value
     fake_get_response.json.return_value = (
         "You must accept the Terms of Use (superstaq.infleqtion.com/terms_of_use)."
     )
@@ -366,7 +366,7 @@ def test_superstaq_client_validate_email_error(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.unauthorized
+    mock_post.return_value.status_code = http.HTTPStatus.UNAUTHORIZED.value
     mock_post.return_value.json.return_value = "You must validate your registered email."
 
     with pytest.raises(
@@ -485,7 +485,7 @@ def test_superstaq_client_create_job_unauthorized(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.unauthorized
+    mock_post.return_value.status_code = http.HTTPStatus.UNAUTHORIZED.value
 
     with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
         _ = client.create_job({"cirq_circuits": "World"}, target="ss_example_qpu")
@@ -501,7 +501,7 @@ def test_superstaq_client_create_job_not_found(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.not_found
+    mock_post.return_value.status_code = http.HTTPStatus.NOT_FOUND.value
 
     with pytest.raises(gss.SuperstaqServerException):
         _ = client.create_job({"qiskit_circuits": "World"}, target="ss_example_qpu")
@@ -539,7 +539,7 @@ def test_superstaq_client_create_job_retry(
         verbose=True,
     )
 
-    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
+    response1 = mock.MagicMock(ok=False, status_code=http.HTTPStatus.SERVICE_UNAVAILABLE.value)
     response1.json.return_value = {"job_id": job_id, "num_circuits": 1}
     response2 = mock.MagicMock(ok=True)
     response2.json.return_value = {"job_id": job_id, "num_circuits": 1}
@@ -628,7 +628,7 @@ def test_superstaq_client_create_job_timeout(mock_post: mock.MagicMock, api_vers
     )
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.service_unavailable
+    mock_post.return_value.status_code = http.HTTPStatus.SERVICE_UNAVAILABLE.value
 
     with pytest.raises(TimeoutError):
         _ = client.create_job({"qiskit_circuits": "World"}, target="ss_example_qpu")
@@ -647,7 +647,7 @@ def test_superstaq_client_create_job_json(
     client = request.getfixturevalue(client_name)
 
     mock_post.return_value.ok = False
-    mock_post.return_value.status_code = requests.codes.bad_request
+    mock_post.return_value.status_code = http.HTTPStatus.BAD_REQUEST.value
     mock_post.return_value.json.return_value = {
         "message": "foo bar",
         "job_id": job_id,
@@ -1026,7 +1026,7 @@ def test_superstaq_client_fetch_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.unauthorized
+        mock_call.return_value.status_code = http.HTTPStatus.UNAUTHORIZED.value
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.fetch_jobs([job_id])
@@ -1049,7 +1049,7 @@ def test_superstaq_client_fetch_jobs_not_found(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.not_found
+        mock_call.return_value.status_code = http.HTTPStatus.NOT_FOUND.value
 
         with pytest.raises(gss.SuperstaqServerException):
             _ = client.fetch_jobs([job_id])
@@ -1072,7 +1072,7 @@ def test_superstaq_client_fetch_jobs_not_retriable(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.bad_request
+        mock_call.return_value.status_code = http.HTTPStatus.BAD_REQUEST.value
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Status code: 400"):
             _ = client.fetch_jobs([job_id])
@@ -1095,7 +1095,7 @@ def test_superstaq_client_fetch_jobs_retry(
 
     response1 = mock.MagicMock()
     response1.ok = False
-    response1.status_code = requests.codes.service_unavailable
+    response1.status_code = http.HTTPStatus.SERVICE_UNAVAILABLE.value
 
     response2 = mock.MagicMock()
     response2.ok = True
@@ -1124,7 +1124,7 @@ def test_superstaq_client_cancel_jobs_unauthorized(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.unauthorized
+        mock_call.return_value.status_code = http.HTTPStatus.UNAUTHORIZED.value
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Not authorized"):
             _ = client.cancel_jobs([job_id])
@@ -1147,7 +1147,7 @@ def test_superstaq_client_cancel_jobs_not_found(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.not_found
+        mock_call.return_value.status_code = http.HTTPStatus.NOT_FOUND.value
 
         with pytest.raises(gss.SuperstaqServerException):
             _ = client.cancel_jobs([job_id])
@@ -1170,7 +1170,7 @@ def test_superstaq_client_get_cancel_jobs_retriable(
 
     with mock.patch(call_type) as mock_call:
         mock_call.return_value.ok = False
-        mock_call.return_value.status_code = requests.codes.bad_request
+        mock_call.return_value.status_code = http.HTTPStatus.BAD_REQUEST.value
 
         with pytest.raises(gss.SuperstaqServerException, match=r"Status code: 400"):
             _ = client.cancel_jobs([job_id], cq_token=1)
@@ -1191,7 +1191,7 @@ def test_superstaq_client_cancel_jobs_retry(
 ) -> None:
     client = request.getfixturevalue(client_name)
 
-    response1 = mock.MagicMock(ok=False, status_code=requests.codes.service_unavailable)
+    response1 = mock.MagicMock(ok=False, status_code=http.HTTPStatus.SERVICE_UNAVAILABLE.value)
     response2 = mock.MagicMock(ok=True)
     if client.api_version == "v0.3.0":
         response2.json.return_value = {

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import datetime
+import http
 import json
 import textwrap
 import uuid
@@ -45,7 +46,7 @@ def mock_response(status_str: str) -> dict[str, str | int | dict[str, int] | Non
 
 def _mocked_request_response(content: object) -> requests.Response:
     response = requests.Response()
-    response.status_code = requests.codes.OK
+    response.status_code = http.HTTPStatus.OK.value
     response._content = json.dumps(content).encode()
     return response
 


### PR DESCRIPTION
`requests` `v2.34.0` was recently released and introduced inline types, replacing the old typeshed-provided stubs. Notably, in `requests~=2.34.*`, `requests.codes` are typed as a [`LookupDict[int]`](https://github.com/psf/requests/blob/6e83187b8feb273ed4c6cdab5efd8d54901dfab3/src/requests/status_codes.py#L106), and `LookupDict.__getattr__ / __getitem__` can [`return _VT | None`](https://github.com/psf/requests/blob/6e83187b8feb273ed4c6cdab5efd8d54901dfab3/src/requests/structures.py#L108-L118) -- meaning `requests.codes.*` can be read as `int | None` by `mypy`. 

This PR replaces use of `request.codes.*` with `http.HTTPStatus` to avoid this issue, along with other typing updates to fix the currently failing type check