### PR TITLE
Parallelize modular coverage tests

### DIFF
--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import os
 import subprocess
 import sys
@@ -104,16 +105,17 @@ def run(
         return _report(test_returncode)
 
     # Run checks on individual files, skipping repeats
-    subprocess.check_call(["python", "-m", "coverage", "erase"])
+    subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
 
     # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in `files`
     # both will be included in the coverage report
     files.sort(
         key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
     )
-    coverage_args.append("--append")
-    test_returncode = 0
+    coverage_args.append("--parallel-mode")
 
+    # Build (files_requiring_coverage, test_files) pairs first, then run all concurrently.
+    pairs: list[tuple[list[str], list[str]]] = []
     while files:
         file = files.pop(0)
         test_files = check_utils.get_test_files([file], exclude=exclude, silent=True)
@@ -132,9 +134,24 @@ def run(
                 files_requiring_coverage.append(test_file)
                 files.remove(test_file)
 
-        test_returncode |= _run_on_files(
-            files_requiring_coverage, test_files, coverage_args, pytest_args
-        )
+        pairs.append((files_requiring_coverage, test_files))
+
+    test_returncode = 0
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_to_pair = {
+            executor.submit(
+                _run_on_files_capturing,
+                files_requiring_coverage,
+                test_files,
+                coverage_args,
+                pytest_args,
+            ): test_files
+            for files_requiring_coverage, test_files in pairs
+        }
+        for future in concurrent.futures.as_completed(future_to_pair):
+            returncode, output = future.result()
+            print(output, end="")  # noqa: T201
+            test_returncode |= returncode
 
     return _report(test_returncode)
 
@@ -147,8 +164,7 @@ def _run_on_files(
 ) -> int:
     """Helper function to run coverage tests on the given files with the given pytest arguments."""
     coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
-
-    test_returncode = subprocess.call(
+    return subprocess.call(
         [
             sys.executable,
             "-m",
@@ -162,7 +178,35 @@ def _run_on_files(
         ],
         cwd=check_utils.root_dir,
     )
-    return test_returncode
+
+
+def _run_on_files_capturing(
+    files_requiring_coverage: list[str],
+    test_files: list[str],
+    coverage_args: list[str],
+    pytest_args: list[str],
+) -> tuple[int, str]:
+    """Like _run_on_files, but captures combined stdout/stderr for safe concurrent printing."""
+    coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            *coverage_args,
+            "-m",
+            "pytest",
+            *test_files,
+            *pytest_args,
+        ],
+        check=False,
+        text=True,
+        cwd=check_utils.root_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return result.returncode, result.stdout
 
 
 def _report(test_returncode: int) -> int:

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -101,7 +101,7 @@ def run(
         return 0
 
     if not parsed_args.modular:
-        test_returncode = _run_on_files(files, test_files, coverage_args, pytest_args)
+        test_returncode, _ = _run_on_files(files, test_files, coverage_args, pytest_args)
         return _report(test_returncode)
 
     # Run checks on individual files, skipping repeats
@@ -140,7 +140,7 @@ def run(
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future_to_pair = {
             executor.submit(
-                _run_on_files_and_capture_output,
+                _run_on_files,
                 files_requiring_coverage,
                 test_files,
                 coverage_args,
@@ -161,34 +161,8 @@ def _run_on_files(
     test_files: list[str],
     coverage_args: list[str],
     pytest_args: list[str],
-) -> int:
-    """Helper function to run coverage tests on the given files with the given pytest arguments."""
-    coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
-
-    test_returncode = subprocess.call(
-        [
-            sys.executable,
-            "-m",
-            "coverage",
-            "run",
-            *coverage_args,
-            "-m",
-            "pytest",
-            *test_files,
-            *pytest_args,
-        ],
-        cwd=check_utils.root_dir,
-    )
-    return test_returncode
-
-
-def _run_on_files_and_capture_output(
-    files_requiring_coverage: list[str],
-    test_files: list[str],
-    coverage_args: list[str],
-    pytest_args: list[str],
 ) -> tuple[int, str]:
-    """Like _run_on_files, but captures combined stdout/stderr for safe concurrent printing."""
+    """Helper function to run coverage tests on the given files with the given pytest arguments."""
     coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
     result = subprocess.run(
         [

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -112,7 +112,7 @@ def run(
 
     if not parsed_args.modular:
         result = _run_on_files(files, test_files, coverage_args, pytest_args)
-        return result.returncode
+        return _report(result.returncode)
 
     return _report(_run_modular(files, coverage_args, pytest_args, exclude, parsed_args.jobs))
 

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -165,7 +165,6 @@ def _run_modular(
         return test_returncode
 
     # Run modular checks concurrently
-    coverage_args.append("--parallel-mode")
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
         jobs = [
             executor.submit(

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -163,7 +163,8 @@ def _run_modular(
         return test_returncode
 
     # Run modular checks concurrently
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
+    max_workers = num_jobs or min((os.cpu_count() or 2) // 2, len(test_files))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         jobs = [
             executor.submit(
                 _run_on_files,

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -140,7 +140,7 @@ def run(
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future_to_pair = {
             executor.submit(
-                _run_on_files_capturing,
+                _run_on_files_and_capture_output,
                 files_requiring_coverage,
                 test_files,
                 coverage_args,
@@ -182,7 +182,7 @@ def _run_on_files(
     return test_returncode
 
 
-def _run_on_files_capturing(
+def _run_on_files_and_capture_output(
     files_requiring_coverage: list[str],
     test_files: list[str],
     coverage_args: list[str],

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -51,13 +51,13 @@ def run(
     )
     parser.add_argument(
         "-j",
-        "--num_workers",
+        "--jobs",
         type=int,
         default=1,
         help="Parallelize modular coverage test across this many concurrent threads. '0' is"
         " interpreted as 'the default number used by concurrent.futures.ThreadPoolExecutor', which"
-        " is 'min(32, (os.cpu_count() or 1) + 4)' at the time of writing. Only relevant for modular"
-        " coverage.",
+        " is 'min(32, (os.cpu_count() or 1) + 4)' at the time of writing. This argument is only"
+        " relevant for modular coverage.",
     )
     parser.add_argument(
         "--branch",
@@ -114,9 +114,7 @@ def run(
         result = _run_on_files(files, test_files, coverage_args, pytest_args)
         return result.returncode
 
-    return _report(
-        _run_modular(files, coverage_args, pytest_args, exclude, parsed_args.num_workers)
-    )
+    return _report(_run_modular(files, coverage_args, pytest_args, exclude, parsed_args.jobs))
 
 
 def _run_modular(
@@ -124,7 +122,7 @@ def _run_modular(
     coverage_args: list[str],
     pytest_args: list[str],
     exclude: str | Iterable[str],
-    num_workers: int,
+    num_jobs: int,
 ) -> int:
     """Run modular coverage checks.  If num_workers != 1, these checks are run concurrently."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
@@ -158,7 +156,7 @@ def _run_modular(
         pairs.append((files_requiring_coverage, test_files))
 
     test_returncode = 0
-    if num_workers == 1:
+    if num_jobs == 1:
         # Run modular checks one at a time.
         coverage_args.append("--append")
         for files_requiring_coverage, test_files in pairs:
@@ -167,7 +165,7 @@ def _run_modular(
     else:
         # Run modular checks concurrently.
         coverage_args.append("--parallel-mode")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers or None) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
             jobs = [
                 executor.submit(
                     _run_on_files,

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -216,6 +216,9 @@ def _report(test_returncode: int) -> int:
         stdout=subprocess.DEVNULL,
     )
 
+    # Flush Python's stdout buffer before the subprocess writes directly to it, so captured
+    # test output appears before the coverage report.
+    sys.stdout.flush()
     coverage_returncode = subprocess.call(
         [sys.executable, "-m", "coverage", "report", "--precision=2"],
         cwd=check_utils.root_dir,

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -134,7 +134,6 @@ def _run_modular(
     files.sort(
         key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
     )
-    coverage_args.append("--append" if num_workers == 1 else "--parallel-mode")
 
     # Build (files_requiring_coverage, test_files) pairs.
     pairs: list[tuple[list[str], list[str]]] = []
@@ -161,11 +160,13 @@ def _run_modular(
     test_returncode = 0
     if num_workers == 1:
         # Run modular checks one at a time.
+        coverage_args.append("--append")
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
             test_returncode |= result.returncode
     else:
         # Run modular checks concurrently.
+        coverage_args.append("--parallel-mode")
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers or None) as executor:
             jobs = [
                 executor.submit(

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -162,26 +162,26 @@ def _run_modular(
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
             test_returncode |= result.returncode
-    else:
-        # Run modular checks concurrently
-        coverage_args.append("--parallel-mode")
-        with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
-            jobs = [
-                executor.submit(
-                    _run_on_files,
-                    files_requiring_coverage,
-                    test_files,
-                    coverage_args,
-                    pytest_args,
-                    capture_output=True,
-                )
-                for files_requiring_coverage, test_files in pairs
-            ]
-            for future in concurrent.futures.as_completed(jobs):
-                result = future.result()
-                print(result.stdout, end="")  # noqa: T201
-                test_returncode |= result.returncode
+        return test_returncode
 
+    # Run modular checks concurrently
+    coverage_args.append("--parallel-mode")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
+        jobs = [
+            executor.submit(
+                _run_on_files,
+                files_requiring_coverage,
+                test_files,
+                coverage_args,
+                pytest_args,
+                capture_output=True,
+            )
+            for files_requiring_coverage, test_files in pairs
+        ]
+        for future in concurrent.futures.as_completed(jobs):
+            result = future.result()
+            print(result.stdout, end="")  # noqa: T201
+            test_returncode |= result.returncode
     return test_returncode
 
 

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -85,7 +85,9 @@ def run(
 
     # Enable threading setting before other args so -n can be overwritten
     default_threads = (
-        "auto"
+        parsed_args.jobs
+        if not parsed_args.modular and parsed_args.jobs is not None
+        else "auto"
         if not parsed_args.files
         and not parsed_args.modular
         and parsed_args.revisions is None

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -54,10 +54,10 @@ def run(
         "--jobs",
         type=int,
         default=1,
-        help="Parallelize modular coverage test across this many concurrent threads. '0' is"
-        " interpreted as 'the default number used by concurrent.futures.ThreadPoolExecutor', which"
-        " is 'min(32, (os.cpu_count() or 1) + 4)' at the time of writing. This argument is only"
-        " relevant for modular coverage.",
+        help="Parallelize modular coverage test across this many concurrent threads. This argument"
+        " is ignored for non-modular coverage tests. '0' is interpreted as 'the default number used"
+        " by concurrent.futures.ThreadPoolExecutor', which is 'min(32, (os.cpu_count() or 1) + 4)'"
+        " at the time of writing.",
     )
     parser.add_argument(
         "--branch",
@@ -127,13 +127,13 @@ def _run_modular(
     """Run modular coverage checks.  If num_workers != 1, these checks are run concurrently."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
 
-    # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in
-    # `files` both will be included in the coverage report.
+    # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in `files`
+    # both will be included in the coverage report
     files.sort(
         key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
     )
 
-    # Build (files_requiring_coverage, test_files) pairs.
+    # Build (files_requiring_coverage, test_files) pairs
     pairs: list[tuple[list[str], list[str]]] = []
     while files:
         file = files.pop(0)
@@ -157,13 +157,13 @@ def _run_modular(
 
     test_returncode = 0
     if num_jobs == 1:
-        # Run modular checks one at a time.
+        # Run modular checks one at a time
         coverage_args.append("--append")
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
             test_returncode |= result.returncode
     else:
-        # Run modular checks concurrently.
+        # Run modular checks concurrently
         coverage_args.append("--parallel-mode")
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs or None) as executor:
             jobs = [
@@ -222,7 +222,7 @@ def _report(test_returncode: int) -> int:
     )
 
     # Flush Python's stdout buffer before the subprocess writes directly to it, so captured
-    # test output appears before the coverage report.
+    # test output appears before the coverage report
     sys.stdout.flush()
     coverage_returncode = subprocess.call(
         [sys.executable, "-m", "coverage", "report", "--precision=2"],

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -50,6 +50,16 @@ def run(
         help="Check that each file is covered by its own test file.",
     )
     parser.add_argument(
+        "-j",
+        "--num_workers",
+        type=int,
+        default=1,
+        help="Parallelize modular coverage test across this many concurrent threads. '0' is"
+        " interpreted as 'the default number used by concurrent.futures.ThreadPoolExecutor', which"
+        " is 'min(32, (os.cpu_count() or 1) + 4)' at the time of writing. Only relevant for modular"
+        " coverage.",
+    )
+    parser.add_argument(
         "--branch",
         action="store_true",
         help="Also require all branches to be covered (same as `coverage run --branch`).",
@@ -101,10 +111,12 @@ def run(
         return 0
 
     if not parsed_args.modular:
-        test_returncode, _ = _run_on_files(files, test_files, coverage_args, pytest_args)
-        return _report(test_returncode)
+        result = _run_on_files(files, test_files, coverage_args, pytest_args)
+        return result.returncode
 
-    return _report(_run_modular(files, coverage_args, pytest_args, exclude))
+    return _report(
+        _run_modular(files, coverage_args, pytest_args, exclude, parsed_args.num_workers)
+    )
 
 
 def _run_modular(
@@ -112,6 +124,7 @@ def _run_modular(
     coverage_args: list[str],
     pytest_args: list[str],
     exclude: str | Iterable[str],
+    num_workers: int,
 ) -> int:
     """Run modular coverage checks concurrently, one (source, test) pair per subprocess."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
@@ -121,9 +134,9 @@ def _run_modular(
     files.sort(
         key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
     )
-    coverage_args.append("--parallel-mode")
+    coverage_args.append("--append" if num_workers == 1 else "--parallel-mode")
 
-    # Build (files_requiring_coverage, test_files) pairs first, then run all concurrently.
+    # Build (files_requiring_coverage, test_files) pairs.
     pairs: list[tuple[list[str], list[str]]] = []
     while files:
         file = files.pop(0)
@@ -146,17 +159,27 @@ def _run_modular(
         pairs.append((files_requiring_coverage, test_files))
 
     test_returncode = 0
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        jobs = [
-            executor.submit(
-                _run_on_files, files_requiring_coverage, test_files, coverage_args, pytest_args
-            )
-            for files_requiring_coverage, test_files in pairs
-        ]
-        for future in concurrent.futures.as_completed(jobs):
-            returncode, output = future.result()
-            print(output, end="")  # noqa: T201
-            test_returncode |= returncode
+    if num_workers == 1:
+        for files_requiring_coverage, test_files in pairs:
+            result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
+            test_returncode |= result.returncode
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers or None) as executor:
+            jobs = [
+                executor.submit(
+                    _run_on_files,
+                    files_requiring_coverage,
+                    test_files,
+                    coverage_args,
+                    pytest_args,
+                    capture_output=True,
+                )
+                for files_requiring_coverage, test_files in pairs
+            ]
+            for future in concurrent.futures.as_completed(jobs):
+                result = future.result()
+                print(result.stdout, end="")  # noqa: T201
+                test_returncode |= result.returncode
 
     return test_returncode
 
@@ -166,10 +189,12 @@ def _run_on_files(
     test_files: list[str],
     coverage_args: list[str],
     pytest_args: list[str],
-) -> tuple[int, str]:
+    *,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess:
     """Helper function to run coverage tests on the given files with the given pytest arguments."""
     coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
-    result = subprocess.run(
+    return subprocess.run(
         [
             sys.executable,
             "-m",
@@ -183,11 +208,9 @@ def _run_on_files(
         ],
         check=False,
         text=True,
-        cwd=check_utils.root_dir,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        stdout=subprocess.PIPE if capture_output else None,
+        stderr=subprocess.STDOUT if capture_output else None,
     )
-    return result.returncode, result.stdout
 
 
 def _report(test_returncode: int) -> int:

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -126,7 +126,7 @@ def _run_modular(
     exclude: str | Iterable[str],
     num_workers: int,
 ) -> int:
-    """Run modular coverage checks concurrently, one (source, test) pair per subprocess."""
+    """Run modular coverage checks.  If num_workers != 1, these checks are run concurrently."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
 
     # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -160,10 +160,12 @@ def _run_modular(
 
     test_returncode = 0
     if num_workers == 1:
+        # Run modular checks one at a time.
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
             test_returncode |= result.returncode
     else:
+        # Run modular checks concurrently.
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers or None) as executor:
             jobs = [
                 executor.submit(

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -158,7 +158,6 @@ def _run_modular(
     test_returncode = 0
     if num_jobs == 1:
         # Run modular checks one at a time
-        coverage_args.append("--append")
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)
             test_returncode |= result.returncode

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -53,11 +53,10 @@ def run(
         "-j",
         "--jobs",
         type=int,
-        default=1,
+        default=None,
         help="Parallelize modular coverage test across this many concurrent threads. This argument"
-        " is ignored for non-modular coverage tests. '0' is interpreted as 'the default number used"
-        " by concurrent.futures.ThreadPoolExecutor', which is 'min(32, (os.cpu_count() or 1) + 4)'"
-        " at the time of writing.",
+        " is ignored for non-modular coverage tests."
+        " Default: min((os.cpu_count() or 2) // 2, len(files))",
     )
     parser.add_argument(
         "--branch",
@@ -122,7 +121,7 @@ def _run_modular(
     coverage_args: list[str],
     pytest_args: list[str],
     exclude: str | Iterable[str],
-    num_jobs: int,
+    num_jobs: int | None,
 ) -> int:
     """Run modular coverage checks.  If num_workers != 1, these checks are run concurrently."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
@@ -156,7 +155,7 @@ def _run_modular(
         pairs.append((files_requiring_coverage, test_files))
 
     test_returncode = 0
-    if num_jobs == 1:
+    if num_jobs == 0:
         # Run modular checks one at a time
         for files_requiring_coverage, test_files in pairs:
             result = _run_on_files(files_requiring_coverage, test_files, coverage_args, pytest_args)

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -104,11 +104,20 @@ def run(
         test_returncode, _ = _run_on_files(files, test_files, coverage_args, pytest_args)
         return _report(test_returncode)
 
-    # Run checks on individual files, skipping repeats
+    return _report(_run_modular(files, coverage_args, pytest_args, exclude))
+
+
+def _run_modular(
+    files: list[str],
+    coverage_args: list[str],
+    pytest_args: list[str],
+    exclude: str | Iterable[str],
+) -> int:
+    """Run modular coverage checks concurrently, one (source, test) pair per subprocess."""
     subprocess.check_call([sys.executable, "-m", "coverage", "erase"], cwd=check_utils.root_dir)
 
-    # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in `files`
-    # both will be included in the coverage report
+    # Move test files to the end of the file list, so if both "x.py" and "x_test.py" are in
+    # `files` both will be included in the coverage report.
     files.sort(
         key=lambda file: file.endswith("_test.py") or os.path.basename(file).startswith("test_")
     )
@@ -138,22 +147,18 @@ def run(
 
     test_returncode = 0
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        future_to_pair = {
+        jobs = [
             executor.submit(
-                _run_on_files,
-                files_requiring_coverage,
-                test_files,
-                coverage_args,
-                pytest_args,
-            ): test_files
+                _run_on_files, files_requiring_coverage, test_files, coverage_args, pytest_args
+            )
             for files_requiring_coverage, test_files in pairs
-        }
-        for future in concurrent.futures.as_completed(future_to_pair):
+        ]
+        for future in concurrent.futures.as_completed(jobs):
             returncode, output = future.result()
             print(output, end="")  # noqa: T201
             test_returncode |= returncode
 
-    return _report(test_returncode)
+    return test_returncode
 
 
 def _run_on_files(

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -193,7 +193,7 @@ def _run_on_files(
     pytest_args: list[str],
     *,
     capture_output: bool = False,
-) -> subprocess.CompletedProcess:
+) -> subprocess.CompletedProcess[str]:
     """Helper function to run coverage tests on the given files with the given pytest arguments."""
     coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
     return subprocess.run(

--- a/checks-superstaq/checks_superstaq/coverage_.py
+++ b/checks-superstaq/checks_superstaq/coverage_.py
@@ -164,7 +164,8 @@ def _run_on_files(
 ) -> int:
     """Helper function to run coverage tests on the given files with the given pytest arguments."""
     coverage_args = ["--include=" + ",".join(files_requiring_coverage), *coverage_args]
-    return subprocess.call(
+
+    test_returncode = subprocess.call(
         [
             sys.executable,
             "-m",
@@ -178,6 +179,7 @@ def _run_on_files(
         ],
         cwd=check_utils.root_dir,
     )
+    return test_returncode
 
 
 def _run_on_files_capturing(


### PR DESCRIPTION
Modular coverage tests currently run one-by-one.  This PR makes them run in parallel.

A point of confusion: I don't see much benefit for the coverage [tests in this PR](https://github.com/Infleqtion/client-superstaq/actions/runs/27630018230) vs. that, say, [here](https://github.com/Infleqtion/client-superstaq/actions/runs/27291828714).  I definitely see a big benefit locally though...  Are github workflows limited to one CPU?