### PR TITLE
fix: update broken Supermarq tutorial link

### DIFF
--- a/supermarq-benchmarks/README.md
+++ b/supermarq-benchmarks/README.md
@@ -36,7 +36,7 @@ after execution on hardware.
 The quantum benchmarks within Supermarq are designed to be scalable, meaning that the benchmarks can be
 instantiated and generated for a wide range of circuit sizes and depths.
 
-The [Supermarq tutorial](https://github.com/Infleqtion/client-superstaq/tree/main/supermarq-benchmarks/examples) notebooks contain an end-to-end example of how to execute the GHZ benchmark
+The [Supermarq tutorial](https://github.com/Infleqtion/client-superstaq/tree/main/docs/source/apps/supermarq/examples) notebooks contain an end-to-end example of how to execute the GHZ benchmark
 using [Superstaq](https://superstaq.infleqtion.com/). The general workflow is as follows:
 
 ```python

--- a/supermarq-benchmarks/README.md
+++ b/supermarq-benchmarks/README.md
@@ -36,7 +36,7 @@ after execution on hardware.
 The quantum benchmarks within Supermarq are designed to be scalable, meaning that the benchmarks can be
 instantiated and generated for a wide range of circuit sizes and depths.
 
-The [Supermarq tutorial](https://github.com/Infleqtion/client-superstaq/tree/main/docs/source/apps/supermarq/examples) notebooks contain an end-to-end example of how to execute the GHZ benchmark
+The [Supermarq tutorial](../docs/source/apps/supermarq/examples) notebooks contain an end-to-end example of how to execute the GHZ benchmark
 using [Superstaq](https://superstaq.infleqtion.com/). The general workflow is as follows:
 
 ```python


### PR DESCRIPTION
## Summary
- replace the broken `supermarq-benchmarks/examples` README link
- point it to the current `docs/source/apps/supermarq/examples` location
- verify the new destination exists in the repository

Closes #1406
