### PR TITLE
Fix API token discovery

### DIFF
--- a/docs/source/resources/developer_guide.rst
+++ b/docs/source/resources/developer_guide.rst
@@ -229,7 +229,7 @@ It is important to never share your Superstaq access key. They should never be c
 
 To prevent accidental sharing to GitHub, you can try the following methods:
 
-- Save your token to ``~/.local/share/super.tech/superstaq-api-key`` (or in any other directory listed `here <https://github.com/SupertechLabs/client-superstaq/blob/b22c911f292ba75e081449d75b937094d53ff13d/general-superstaq/general_superstaq/superstaq_client.py#L463-L470>`__), for example with
+- Save your token to ``~/.local/share/super.tech/superstaq-api-key`` (or in any other directory listed `here <https://github.com/Infleqtion/client-superstaq/blob/fc1a69e4672a046dc4ed5f007b609462e15d958c/general-superstaq/general_superstaq/superstaq_client.py#L1780-L1787>`__), for example with
 
 .. code-block:: bash
 

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -1785,10 +1785,11 @@ def find_api_key() -> str:
         home_dir.joinpath(".super.tech"),
         home_dir.joinpath(".coldquanta"),
     ]:
-        path = directory.joinpath("superstaq_api_key")
-        if path.is_file():
-            with open(path) as file:
-                return file.readline()
+        for filename in ["superstaq_api_key", "superstaq-api-key"]:
+            path = directory.joinpath(filename)
+            if path.is_file():
+                with open(path) as file:
+                    return file.readline().strip()
 
     raise OSError(
         "Superstaq API key not specified and not found.\n"

--- a/general-superstaq/general_superstaq/superstaq_client_test.py
+++ b/general-superstaq/general_superstaq/superstaq_client_test.py
@@ -2017,6 +2017,18 @@ def test_find_api_key() -> None:
     ):
         assert gss.superstaq_client.find_api_key() == "tomyheart"
 
+    # find key in the legacy hyphenated config filename
+    with (
+        mock.patch.dict(os.environ, SUPERSTAQ_API_KEY=""),
+        mock.patch(
+            "pathlib.Path.is_file",
+            autospec=True,
+            side_effect=lambda path: str(path).endswith("superstaq-api-key"),
+        ),
+        mock.patch("builtins.open", mock.mock_open(read_data="tomyheart\n")),
+    ):
+        assert gss.superstaq_client.find_api_key() == "tomyheart"
+
     # fail to find an API key :(
     with (
         pytest.raises(EnvironmentError, match=r"Superstaq API key not specified and not found."),


### PR DESCRIPTION
Reading the docs for [API token safety](https://github.com/Infleqtion/client-superstaq/blob/9e0017a915e16854a75b25711687704f6e4c2309/docs/source/resources/developer_guide.rst#token-safety), it is recommended to save the token at `~/.local/share/super.tech/superstaq-api-key`. However, looking at [the code](https://github.com/Infleqtion/client-superstaq/blob/b22c911f292ba75e081449d75b937094d53ff13d/general-superstaq/general_superstaq/superstaq_client.py#L463-L470), it should actually be saved at `~/.local/share/super.tech/superstaq_api_key` (underscored instead of hyphenated).

I created a fix to check for both `superstaq-api-key` and `superstaq_api_key` for the API token.