### PR TITLE
Delete unnecessary ending period for docs copyright

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Superstaq"
-copyright = "2026, Infleqtion, Inc."  # noqa: A001
+copyright = "2026, Infleqtion, Inc"  # noqa: A001
 author = "Infleqtion, Inc."
 
 DOCS_GITHUB_ORG = "Infleqtion"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Superstaq"
-copyright = "2026, Infleqtion, Inc"  # noqa: A001
+copyright = "2026 Infleqtion, Inc"  # noqa: A001
 author = "Infleqtion, Inc."
 
 DOCS_GITHUB_ORG = "Infleqtion"


### PR DESCRIPTION
https://github.com/Infleqtion/client-superstaq/pull/1404 updated the docs copyright from `ColdQuanta, Inc., DBA Infleqtion` to `Infleqtion, Inc.`. However, the docs generate an ending period for the copyright name, leading to the following duplication: 
<img width="1466" height="212" alt="image" src="https://github.com/user-attachments/assets/2a436a87-559c-451d-b638-602230537f89" />

This PR fixes this issue by omitting the hardcoded period (tested by building docs locally)