### PR TITLE
bump minimum cirq version

### DIFF
--- a/cirq-superstaq/requirements.txt
+++ b/cirq-superstaq/requirements.txt
@@ -1,2 +1,2 @@
-cirq-core>=1.0.0
+cirq-core>=1.3.0
 general-superstaq~=0.5.66


### PR DESCRIPTION
python 3.9 supports up to cirq==1.3.0. this is ~2.5 years old, so afaict no reason to support anything less