### PR TITLE
fix bug in `css.JobV3._terminal_measurement_qubit_indices`

### DIFF
--- a/cirq-superstaq/cirq_superstaq/job.py
+++ b/cirq-superstaq/cirq_superstaq/job.py
@@ -822,9 +822,9 @@ class JobV3(gss.job.Job):
         return dict(combined)
 
     def _terminal_measurement_qubit_indices(self, index: int) -> list[int]:
-        """Determines the ordered physical qubit indices for each measurement in a compiled circuit.
+        """Determines the physical qubit index corresponding to each bit in a measured bitstring.
 
-        Assumes all measurements are terminal.
+        The given circuit must already be compiled, and contain only terminal measurements.
 
         Args:
             index: The index of the compiled circuit for which to return qubit indices.
@@ -832,12 +832,22 @@ class JobV3(gss.job.Job):
         Returns:
             A list of measured qubit indices, ordered as they should appear in (big-endian)
             bitstrings.
-        """
-        indices = super()._terminal_measurement_qubit_indices(index)
 
-        circuit = self.input_circuits(index)
+        Raises:
+            ValueError: If the circuit contains non-terminal measurements.
+        """
+        circuit = self.compiled_circuits(index)
+
+        # The parent (`gss.Job`) method assumes all active qubits are measured at the end of the
+        # circuit. If the circuit includes explicit measurement operations, we should only include
+        # indices corresponding to qubits which are actually measured, ordered according to their
+        # measurement keys (if there are multiple measurements in a Cirq circuit, Superstaq's
+        # convention is to combine them into a bitstring alphabetically by key).
         if circuit.has_measurements():
-            assert circuit.are_all_measurements_terminal()
+            if not circuit.are_all_measurements_terminal():
+                raise ValueError(
+                    "This functionality is only supported for circuits with terminal measurements."
+                )
 
             key_to_qids: dict[str, tuple[cirq.Qid, ...]] = {}
             for _, op in circuit.findall_operations(cirq.is_measurement):
@@ -848,10 +858,12 @@ class JobV3(gss.job.Job):
             for key in sorted(key_to_qids):
                 qid_list.extend(key_to_qids[key])
 
-            circuit_qubits = sorted(circuit.all_qubits())
-            indices = [indices[circuit_qubits.index(q)] for q in qid_list]
+            physical_qubits = cirq.read_json(json_text=self.job_data.physical_qubits[index])
+            return [physical_qubits.index(q) for q in qid_list]
 
-        return indices
+        # If the circuit contains no measurements, fall back on parent behavior (i.e. assume all
+        # active qubits in the input circuit are measured in order at the end of the circuit).
+        return super()._terminal_measurement_qubit_indices(index)
 
     def __repr__(self) -> str:
         return f"css.JobV3(client={self._client!r}, job_id={self.job_id()!r})"

--- a/cirq-superstaq/cirq_superstaq/job.py
+++ b/cirq-superstaq/cirq_superstaq/job.py
@@ -770,12 +770,14 @@ class JobV3(gss.job.Job):
             A list of measured qubit indices, ordered as they should appear in (big-endian)
             bitstrings.
         """
-        compiled_circuit = self.compiled_circuits(index)
-        assert compiled_circuit.are_all_measurements_terminal()
+        indices = super()._terminal_measurement_qubit_indices(index)
 
-        if compiled_circuit.has_measurements():
+        circuit = self.input_circuits(index)
+        if circuit.has_measurements():
+            assert circuit.are_all_measurements_terminal()
+
             key_to_qids: dict[str, tuple[cirq.Qid, ...]] = {}
-            for _, op in compiled_circuit.findall_operations(cirq.is_measurement):
+            for _, op in circuit.findall_operations(cirq.is_measurement):
                 key = cirq.measurement_key_name(op)
                 key_to_qids[key] = op.qubits
 
@@ -783,10 +785,10 @@ class JobV3(gss.job.Job):
             for key in sorted(key_to_qids):
                 qid_list.extend(key_to_qids[key])
 
-            circuit_qubits = sorted(compiled_circuit.all_qubits())
-            return [circuit_qubits.index(q) for q in qid_list]
+            circuit_qubits = sorted(circuit.all_qubits())
+            indices = [indices[circuit_qubits.index(q)] for q in qid_list]
 
-        return super()._terminal_measurement_qubit_indices(index)
+        return indices
 
     def __repr__(self) -> str:
         return f"css.JobV3(client={self._client!r}, job_id={self.job_id()!r})"

--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -863,7 +863,7 @@ def test_set_counts_jaqal(
         """\
         from qscout.v1.std usepulses *
 
-        register allqubits[3]
+        register allqubits[5]
 
         prepare_all
         R allqubits[2] 0 3.141592653589793
@@ -873,11 +873,11 @@ def test_set_counts_jaqal(
     result = jaqalpaq_run.run_jaqal_string(jaqal_str, overrides={"__repeats__": 1000})
 
     q0, q1, q2 = cirq.LineQubit.range(3)
-    compiled_circuit = cirq.Circuit(cirq.X(q2), css.barrier(q0, q1, q2))
+    circuit = cirq.Circuit(cirq.X(q2), css.barrier(q0, q1, q2))
     mock_get.return_value.json.return_value = {str(uuid.UUID(int=42)): job_dictV3}
 
     jobV3.job_data.final_logical_to_physicals[0] = {0: 0, 1: 1, 2: 2}
-    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(compiled_circuit)
+    jobV3.job_data.input_circuits[0] = css.serialize_circuits(circuit)
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"001": 1000}
 
@@ -885,22 +885,29 @@ def test_set_counts_jaqal(
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"010": 1000}
 
-    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
-        compiled_circuit + cirq.measure(q2, q1, q0)
-    )
+    jobV3.job_data.final_logical_to_physicals[0] = {0: 2, 1: 3, 2: 4}
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"100": 1000}
 
-    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
-        compiled_circuit + cirq.Circuit(css.barrier(q0, q1, q2), cirq.measure(q1), cirq.measure(q2))
+    jobV3.job_data.final_logical_to_physicals[0] = {0: 0, 1: 1, 2: 2}
+    jobV3.job_data.input_circuits[0] = css.serialize_circuits(circuit + cirq.measure(q2, q1, q0))
+    jobV3.set_counts(result)
+    assert jobV3.counts(0) == {"100": 1000}
+
+    jobV3.job_data.input_circuits[0] = css.serialize_circuits(
+        circuit + cirq.Circuit(css.barrier(q0, q1, q2), cirq.measure(q1), cirq.measure(q2))
     )
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"01": 1000}
 
-    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
-        compiled_circuit
+    jobV3.job_data.final_logical_to_physicals[0] = {0: 2, 1: 3, 2: 4}
+    jobV3.set_counts(result)
+    assert jobV3.counts(0) == {"00": 1000}
+
+    jobV3.job_data.input_circuits[0] = css.serialize_circuits(
+        circuit
         + cirq.Circuit(
-            css.barrier(q0, q1, q2), cirq.measure(q1, key="b"), cirq.measure(q2, key="a")
+            css.barrier(q0, q1, q2), cirq.measure(q1, key="b"), cirq.measure(q0, key="a")
         )
     )
     jobV3.set_counts(result)

--- a/cirq-superstaq/cirq_superstaq/job_test.py
+++ b/cirq-superstaq/cirq_superstaq/job_test.py
@@ -119,8 +119,8 @@ def job_dictV3() -> dict[str, object]:
         "last_updated_timestamp": [datetime.datetime.now(tz=datetime.timezone.utc)],
         "initial_logical_to_physicals": [{0: 0, 1: 1}],
         "final_logical_to_physicals": [{0: 0, 1: 1}],
-        "logical_qubits": ["0", "1"],
-        "physical_qubits": ["0", "1"],
+        "logical_qubits": [cirq.to_json(cirq.LineQubit.range(4))],
+        "physical_qubits": [cirq.to_json(cirq.GridQubit.rect(2, 2))],
         "tags": ["some", "tags"],
         "metadata": {"foo": "bar"},
     }
@@ -864,43 +864,51 @@ def test_set_counts_jaqal(
     )
     result = jaqalpaq_run.run_jaqal_string(jaqal_str, overrides={"__repeats__": 1000})
 
-    q0, q1, q2 = cirq.LineQubit.range(3)
-    circuit = cirq.Circuit(cirq.X(q2), css.barrier(q0, q1, q2))
+    q0, q1, q2, q3, q4 = cirq.LineQubit.range(5)
+    circuit = cirq.Circuit(cirq.X(q2), css.barrier(q1, q2, q3))
+
     mock_get.return_value.json.return_value = {str(uuid.UUID(int=42)): job_dictV3}
 
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(circuit)
     jobV3.job_data.final_logical_to_physicals[0] = {0: 0, 1: 1, 2: 2}
-    jobV3.job_data.input_circuits[0] = css.serialize_circuits(circuit)
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"001": 1000}
-
-    jobV3.job_data.final_logical_to_physicals[0] = {0: 1, 1: 2, 2: 0}
-    jobV3.set_counts(result)
-    assert jobV3.counts(0) == {"010": 1000}
 
     jobV3.job_data.final_logical_to_physicals[0] = {0: 2, 1: 3, 2: 4}
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"100": 1000}
 
-    jobV3.job_data.final_logical_to_physicals[0] = {0: 0, 1: 1, 2: 2}
-    jobV3.job_data.input_circuits[0] = css.serialize_circuits(circuit + cirq.measure(q2, q1, q0))
+    jobV3.job_data.final_logical_to_physicals[0] = {0: 4, 1: 3, 2: 2, 3: 1}
     jobV3.set_counts(result)
-    assert jobV3.counts(0) == {"100": 1000}
+    assert jobV3.counts(0) == {"0010": 1000}
 
-    jobV3.job_data.input_circuits[0] = css.serialize_circuits(
-        circuit + cirq.Circuit(css.barrier(q0, q1, q2), cirq.measure(q1), cirq.measure(q2))
+    jobV3.job_data.physical_qubits[0] = cirq.to_json([q0, q1, q2, q3, q4])
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(circuit + cirq.measure(q1, q2, q3))
+    jobV3.set_counts(result)
+    assert jobV3.counts(0) == {"010": 1000}
+
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(circuit + cirq.measure(q2, q4))
+    jobV3.set_counts(result)
+    assert jobV3.counts(0) == {"10": 1000}
+
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(circuit + cirq.measure(q4, q2))
+    jobV3.set_counts(result)
+    assert jobV3.counts(0) == {"01": 1000}
+
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
+        circuit + cirq.measure(q0, key="a") + cirq.measure(q2, key="b")
     )
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"01": 1000}
 
-    jobV3.job_data.final_logical_to_physicals[0] = {0: 2, 1: 3, 2: 4}
-    jobV3.set_counts(result)
-    assert jobV3.counts(0) == {"00": 1000}
-
-    jobV3.job_data.input_circuits[0] = css.serialize_circuits(
-        circuit
-        + cirq.Circuit(
-            css.barrier(q0, q1, q2), cirq.measure(q1, key="b"), cirq.measure(q0, key="a")
-        )
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
+        circuit + cirq.measure(q0, key="b") + cirq.measure(q2, key="a")
     )
     jobV3.set_counts(result)
     assert jobV3.counts(0) == {"10": 1000}
+
+    jobV3.job_data.compiled_circuits[0] = css.serialize_circuits(
+        cirq.Circuit(cirq.measure(q0), cirq.CZ(q0, q1), cirq.measure(q1))
+    )
+    with pytest.raises(ValueError, match=r"only supported for circuits with terminal measurements"):
+        jobV3.set_counts(result)

--- a/general-superstaq/general_superstaq/job.py
+++ b/general-superstaq/general_superstaq/job.py
@@ -318,9 +318,9 @@ class Job:
         self.job_data.counts = self.job_data.counts  # Trigger revalidation
 
     def _terminal_measurement_qubit_indices(self, index: int) -> list[int]:
-        """Determines the ordered physical qubit indices for each measurement in a compiled circuit.
+        """Determines the physical qubit index corresponding to each bit in a measured bitstring.
 
-        Assumes all measurements are terminal.
+        The given circuit must already be compiled, and contain only terminal measurements.
 
         Args:
             index: The index of the compiled circuit for which to return qubit indices.
@@ -328,6 +328,9 @@ class Job:
         Returns:
             A list of measured qubit indices, ordered as they should appear in (big-endian)
             bitstrings.
+
+        Raises:
+            ValueError: If the circuit has not been compiled.
         """
         logical_to_physical = self.job_data.final_logical_to_physicals[index]
         if logical_to_physical is None:

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_job.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_job.py
@@ -479,9 +479,9 @@ class SuperstaqJobV3(gss.job.Job, qiskit.providers.JobV1):
         return self.input_circuits(index).num_clbits
 
     def _terminal_measurement_qubit_indices(self, index: int) -> list[int]:
-        """Determines the ordered physical qubit indices for each measurement in a compiled circuit.
+        """Determines the physical qubit index corresponding to each bit in a measured bitstring.
 
-        Assumes all measurements are terminal.
+        The given circuit must already be compiled, and contain only terminal measurements.
 
         Args:
             index: The index of the compiled circuit for which to return qubit indices.
@@ -489,13 +489,24 @@ class SuperstaqJobV3(gss.job.Job, qiskit.providers.JobV1):
         Returns:
             A list of measured qubit indices, ordered as they should appear in (big-endian)
             bitstrings.
+
+        Raises:
+            ValueError: If the circuit contains non-terminal measurements.
         """
         compiled_circuit = self.compiled_circuits(index)
 
+        # Compiled Qiskit circuits are always contain all device qubits, so we can use the qubit
+        # indices of terminal measurements directly (if present)
         classical_bit_mapping = qss.classical_bit_mapping(compiled_circuit)
         if classical_bit_mapping:
+            if "measure" in compiled_circuit.remove_final_measurements(inplace=False).count_ops():
+                raise ValueError(
+                    "This functionality is only supported for circuits with terminal measurements."
+                )
             return [classical_bit_mapping[i] for i in sorted(classical_bit_mapping)]
 
+        # If the circuit contains no measurements, fall back on parent behavior (i.e. assume all
+        # active qubits in the input circuit are measured in order at the end of the circuit).
         return super()._terminal_measurement_qubit_indices(index)
 
     def result(

--- a/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
+++ b/qiskit-superstaq/qiskit_superstaq/superstaq_job_test.py
@@ -1109,3 +1109,9 @@ def test_set_counts_jaqal(mock_client: gss.superstaq_client._SuperstaqClientV3) 
     job.job_data.compiled_circuits = [qss.serialize_circuits(circuit)]
     job.set_counts(result)
     assert job.result().get_counts(0) == {"01": 1000}
+
+    circuit.x(1)
+    circuit.measure(1, 1)
+    job.job_data.compiled_circuits = [qss.serialize_circuits(circuit)]
+    with pytest.raises(ValueError, match=r"only supported for circuits with terminal measurements"):
+        job.set_counts(result)


### PR DESCRIPTION
this is used to parse Jaqal results. currently it's incorrect if the compiled circuit uses a subset of the device's qubits (jaqal results are always constructed as if every qubit is measured)