### PR TITLE
stop autodetecting integration tests in pytest_.py

### DIFF
--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -95,12 +95,7 @@ def run(
             "--force-enable-socket",
             f"--nbmake-timeout={NBMAKE_TIMEOUT}",
         ]
-    elif (parsed_args.integration) or (
-        "--integration" not in args
-        and any(re.match(r".*_integration_test\.py$", arg) for arg in args)
-    ):
-        args_to_pass += ["--force-enable-socket"]
-    else:
+    elif not parsed_args.integration:
         files = check_utils.get_test_files(files, exclude=exclude, silent=silent)
 
     if not files:

--- a/checks-superstaq/checks_superstaq/pytest_.py
+++ b/checks-superstaq/checks_superstaq/pytest_.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import re
 import subprocess
 import sys
 import textwrap


### PR DESCRIPTION
currently pytest_.py will automatically switch to integration mode if it detects `*integration_test.py` in any passed arg, even when the passed args are e.g. `--exclude *_integration_test.py` :)

instead we should require `--integration` to be passed manually