### PR TITLE
Lint check update to support `ruff` `v0.16.0`

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -132,8 +132,8 @@ lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Enable `from __future__ import annotations` simplification for rules
 lint.future-annotations = true
 
-# Allow up to ten positional arguments for PLR0917 rule
-lint.pylint.max-positional-args = 10
+# Allow up to twelve positional arguments for PLR0917 rule
+lint.pylint.max-positional-args = 12
 
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = ["collections.abc"]

--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -22,6 +22,7 @@ lint.select = [
   "B",      # flake8-bugbear checks
   "C",      # flake8-comprehensions, mccabe checks
   "COM818", # trailing-comma-on-bare-tuple error
+  "CPY",    # missing-copyright-notice
   "D",      # pydocstyle checks
   "DTZ",    # flake8-datetimez checks
   "E",      # pycodestyle checks
@@ -131,6 +132,9 @@ lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Enable `from __future__ import annotations` simplification for rules
 lint.future-annotations = true
 
+# Allow up to ten positional arguments for PLR0917 rule
+lint.pylint.max-positional-args = 10
+
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = ["collections.abc"]
 
@@ -138,7 +142,7 @@ exempt-modules = ["collections.abc"]
 docstring-code-format = true
 
 [tool.ruff.lint.per-file-ignores]
-"*.ipynb" = ["D101", "D102", "D103", "E501", "ERA001", "T201"]
+"*.ipynb" = ["CPY", "D101", "D102", "D103", "E501", "ERA001", "T201"]
 "*test.py" = ["D101", "D102", "D103", "N802", "N803", "S105", "S106"]
 
 [tool.ruff.lint.pydocstyle]

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -535,7 +535,8 @@ class Service(gss.Service, Generic[CssCompileResultT_co]):
         random_seed: int | None = None,
         target: str = "aqt_keysight_qpu",
         atol: float | None = None,
-        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None] | None = None,
+        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None]
+        | None = None,
         **kwargs: Any,
     ) -> CssCompileResultT_co:
         """Compiles and optimizes the given circuit(s) for AQT using ECA.
@@ -599,7 +600,8 @@ class Service(gss.Service, Generic[CssCompileResultT_co]):
         num_eca_circuits: int | None = None,
         random_seed: int | None = None,
         atol: float | None = None,
-        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None] | None = None,
+        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None]
+        | None = None,
         gateset: Mapping[str, Sequence[Sequence[int]]] | None = None,
         pulses: object = None,
         variables: object = None,

--- a/cirq-superstaq/cirq_superstaq/service.py
+++ b/cirq-superstaq/cirq_superstaq/service.py
@@ -535,8 +535,7 @@ class Service(gss.Service, Generic[CssCompileResultT_co]):
         random_seed: int | None = None,
         target: str = "aqt_keysight_qpu",
         atol: float | None = None,
-        gate_defs: None
-        | (Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None]) = None,
+        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None] | None = None,
         **kwargs: Any,
     ) -> CssCompileResultT_co:
         """Compiles and optimizes the given circuit(s) for AQT using ECA.
@@ -600,8 +599,7 @@ class Service(gss.Service, Generic[CssCompileResultT_co]):
         num_eca_circuits: int | None = None,
         random_seed: int | None = None,
         atol: float | None = None,
-        gate_defs: None
-        | (Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None]) = None,
+        gate_defs: Mapping[str, npt.NDArray[np.number[Any]] | cirq.Gate | cirq.Operation | None] | None = None,
         gateset: Mapping[str, Sequence[Sequence[int]]] | None = None,
         pulses: object = None,
         variables: object = None,

--- a/general-superstaq/general_superstaq/superstaq_client.py
+++ b/general-superstaq/general_superstaq/superstaq_client.py
@@ -387,7 +387,7 @@ class _BaseSuperstaqClient:
 class _AbstractUserClient(_BaseSuperstaqClient, ABC):
     """Abstract base class for V2 and V3 clients."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0917
         self,
         client_name: str,
         api_key: str | None = None,


### PR DESCRIPTION
Fixes failing lint check due to the release of `ruff==0.16.0` (changelog [here](https://astral.sh/blog/ruff-v0.16.0))

Applicable changes include the CPY001, RUF036, and PLR0917 rules coming out of preview and associated config updates