### PR TITLE
fix overridden pytest options

### DIFF
--- a/checks-superstaq/checks_superstaq/checks-pyproject.toml
+++ b/checks-superstaq/checks_superstaq/checks-pyproject.toml
@@ -1,11 +1,12 @@
 # Check script configuration:
 
-[tool.pytest.ini_options]
-addopts = "--disable-socket"
+[tool.pytest]
+addopts = ["--disable-socket"]
 filterwarnings = [
   "ignore::UserWarning:qtrl.*",
   "ignore::PendingDeprecationWarning:qtrl.utils.config",
   "ignore::PendingDeprecationWarning:ruamel.yaml.main",
+  "ignore:Version v0.3.0",
 ]
 
 [tool.ruff]

--- a/general-superstaq/pyproject.toml
+++ b/general-superstaq/pyproject.toml
@@ -16,9 +16,6 @@ homepage = "https://github.com/Infleqtion/client-superstaq"
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.pytest.ini_options]
-filterwarnings = ["ignore: Version v0.3.0"]
-
 [tool.setuptools.packages.find]
 include = ["general_superstaq*"]
 


### PR DESCRIPTION
our global pytest settings (e.g. passing `--disable-socket`) seem to have been overridden in #1192